### PR TITLE
feat(rockets-core): export compileDtoClass and namedZodDto from the zod subpath

### DIFF
--- a/packages/rockets-core/src/zod/index.ts
+++ b/packages/rockets-core/src/zod/index.ts
@@ -27,6 +27,7 @@ export type {
   RocketsRelationTarget,
   UnwrappedField,
 } from './field-meta';
+export { compileDtoClass, namedZodDto } from './zod-dto';
 export { f } from './fields';
 export {
   WireRow,


### PR DESCRIPTION
## What

Re-exports `compileDtoClass` and `namedZodDto` from `@bitwild/rockets-core/zod` (one line in `src/zod/index.ts`).

## Why

Classic `defineResource` consumers who hand-author zod DTOs need the same `@Exclude`/`@Expose` compilation the zod resource layer applies internally — the crud response path serializes through class-transformer with `excludeExtraneousValues`, so a bare nestjs-zod `createZodDto` class (no `@Expose` metadata) serializes every row as `{}`.

`zodResource` isn't always an option: it generates a new entity, which duplicates hand-tuned entities (custom PK defaults, `enumName`s, `asExpression` generated columns).

## Validation

Consumed downstream in a NestJS 12 (ESM, `nodenext`) app over postgres: hand-written zod schemas → `compileDtoClass` → `defineResource` DTOs, covered by that app's HTTP integration suite (list/read/create/update responses fully populated, strict-schema 400s intact). Happy to add an upstream e2e spec if you'd like it in this PR.