### PR TITLE
fix(rockets-auth): enforce the active flag on token validation; patch RepositoryQueryException context wipe

### DIFF
--- a/packages/rockets-server-auth/src/provider/rockets-jwt-auth.adapter.ts
+++ b/packages/rockets-server-auth/src/provider/rockets-jwt-auth.adapter.ts
@@ -63,6 +63,15 @@ export class RocketsJwtAuthAdapter implements AuthAdapterInterface {
     }
 
     const user = userAggregateToEntity(userResult);
+
+    // Honor the user's active flag on EVERY request, matching login semantics
+    // (LocalService throws LocalUserInactiveException): a deactivated user's
+    // outstanding access tokens must stop working immediately.
+    if (user.active !== true) {
+      this.logger.warn(`User inactive for subject: ${payload.sub}`);
+      throw new UnauthorizedException('User inactive');
+    }
+
     const userRoles = await resolveUserRoles(this.queryBus, user.id);
 
     this.logger.log(`Successfully validated token for user: ${payload.sub}`);

--- a/scripts/patch-concepta-runtime-context.cjs
+++ b/scripts/patch-concepta-runtime-context.cjs
@@ -21,6 +21,7 @@ const files = [
   'node_modules/@concepta/nestjs-common/dist/model/exceptions/model-id-no-match.exception.js',
   'node_modules/@concepta/nestjs-crud/dist/infrastructure/exceptions/crud.exception.js',
   'node_modules/@concepta/nestjs-crud/dist/infrastructure/exceptions/crud-query.exception.js',
+  'node_modules/@concepta/nestjs-repository/dist/exceptions/repository-query.exception.js',
 ];
 
 const needle = 'Object.assign({}, super.context)';


### PR DESCRIPTION
## What

Two small fixes found while running rockets-auth in production-shaped integration tests:

1. **`RocketsJwtAuthAdapter` now rejects inactive users during access-token validation.** Login already enforces `active` (`LocalUserInactiveException`), but the token path did not — a deactivated user's outstanding access tokens kept working until expiry. The adapter now checks `user.active` after the subject lookup and fails with 401, mirroring the login-path semantics.

2. **`scripts/patch-concepta-runtime-context.cjs` also patches `@concepta/nestjs-repository`.** `RepositoryQueryException` has the same `Object.assign({}, super.context)` bug as the nestjs-common/nestjs-crud exceptions the script already fixes: the derived constructor wipes `context.originalError`, so consumers can never reach the underlying driver error (e.g. to map postgres `23505` unique violations to 409 Conflict).

## Validation

Verified downstream (NestJS 12 ESM app, postgres, HTTP integration suite): deactivating a user 401s their live access token on the very next request and reactivation restores it; with the repository patch applied, unique violations surface through `context.originalError` and map to 409. Happy to add upstream e2e coverage for the active gate if wanted.