### PR TITLE
fix(firestore): match Unicode map key ordering

### DIFF
--- a/packages/rockets-repository-firestore/src/__tests__/firestore-backend.emulator-spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-backend.emulator-spec.ts
@@ -25,6 +25,14 @@ describe('Firestore backend emulator parity', () => {
       ['null', { profile: { score: null }, kind: 'null' }],
       ['number', { profile: { score: 2 }, kind: 'number', at: new Date(10) }],
       ['string', { profile: { score: '2' }, kind: 'string' }],
+      [
+        'map-code-point-first',
+        { unicodeMap: { '\uE000': 1, '😀': 2 }, kind: 'map' },
+      ],
+      [
+        'map-code-point-second',
+        { unicodeMap: { '\uE000': 2, '😀': 1 }, kind: 'map' },
+      ],
     ];
     for (const backend of backends) {
       for (const [id, row] of rows) await backend.set(collection, id, row);
@@ -72,5 +80,16 @@ describe('Firestore backend emulator parity', () => {
     });
     expect(rows.map((row) => row.id)).toEqual(['null', 'number', 'string']);
     expect((await admin.get(collection, 'number'))?.at).toBeInstanceOf(Date);
+  });
+
+  it('matches server map ordering for Unicode keys', async () => {
+    const rows = await compare({
+      branch: { filters: [], postFilters: [] },
+      orderBy: [{ field: 'unicodeMap', direction: 'asc' }],
+    });
+    expect(rows.map((row) => row.id)).toEqual([
+      'map-code-point-first',
+      'map-code-point-second',
+    ]);
   });
 });

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-value.spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-value.spec.ts
@@ -183,6 +183,15 @@ describe('local Firestore value semantics', () => {
     ).toBeLessThan(0);
   });
 
+  it('orders map values by Unicode code-point key order', () => {
+    expect(
+      compareFirestoreValues(
+        { '\uE000': 1, '😀': 2 },
+        { '\uE000': 2, '😀': 1 },
+      ),
+    ).toBeLessThan(0);
+  });
+
   it('orders supported scalars and excludes missing ordered fields', () => {
     const rows = [
       { id: 'missing' },

--- a/packages/rockets-repository-firestore/src/repository/firestore-value.ts
+++ b/packages/rockets-repository-firestore/src/repository/firestore-value.ts
@@ -227,8 +227,8 @@ function compareMaps(
   right: Record<string, unknown>,
   field?: string,
 ): number {
-  const leftKeys = Object.keys(left).sort();
-  const rightKeys = Object.keys(right).sort();
+  const leftKeys = Object.keys(left).sort(compareStrings);
+  const rightKeys = Object.keys(right).sort(compareStrings);
   const commonLength = Math.min(leftKeys.length, rightKeys.length);
 
   for (let index = 0; index < commonLength; index += 1) {


### PR DESCRIPTION
# Pull Request

## Summary

Make the in-memory Firestore comparator order map keys by the same Unicode code-point/UTF-8 ordering used by Firestore, instead of JavaScript's default UTF-16 code-unit ordering. This fixes incorrect ordering when a map mixes astral-plane and BMP keys.

## Changes

- Sort map keys with the existing Firestore string comparator before comparing key/value pairs.
- Add a focused regression for `U+E000` versus `U+1F600`, where JavaScript and Firestore ordering differ.
- Add emulator-backed parity coverage proving that native Firestore ordering and the local comparator agree.

Firestore contract: https://firebase.google.com/docs/firestore/manage-data/data-types

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Dependency update

## Verification

- [x] Build succeeds (`corepack yarn workspace @concepta/rockets-repository-firestore build`)
- [x] Unit tests pass (50/50)
- [x] E2E tests pass (Firestore emulator 4/4)
- [x] Lint passes (changed files with the repository ESLint config)
- [x] `git diff --check origin/main...HEAD`
- [x] Independent cross-review found no actionable findings

## Checklist

- [x] My code follows the existing patterns in the codebase
- [x] Relevant behavior is covered by the existing Firestore contract documentation
- [x] I have added tests for new functionality
