### PR TITLE
feat(firestore): p1 transactions + soft-delete pushdown

### DIFF
--- a/.github/workflows/ci-pr-test.yml
+++ b/.github/workflows/ci-pr-test.yml
@@ -1,8 +1,9 @@
 name: ci-pr-test
 
 on:
+  # No base-branch filter: stacked PRs (branch → branch → main) must be gated
+  # too. Filtering on 'main' left them with zero checks.
   pull_request:
-    branches: ['main']
 
 jobs:
   build:

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -3,8 +3,10 @@ name: release-readiness
 # Gate-only: ci-pr-test already runs build/lint/typecheck/unit/e2e on every
 # pull request. This workflow adds only the release gates it does not cover.
 on:
+  # Runs on every pull request, including stacked ones — the Firestore emulator
+  # suite is the only gate for the Admin SDK path, so skipping it on non-main
+  # bases meant those claims shipped unverified.
   pull_request:
-    branches: ['main']
   push:
     branches: ['main']
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,13 @@ Per-package release notes live in `packages/*/CHANGELOG.md`.
 - Firestore soft-delete server pushdown (issue #44 P1-4): default lists/counts
   use `field == null`, restoring `limit()` / aggregation. **Requires a data
   backfill and composite indexes before deploy** — see the package CHANGELOG.
-  Includes `backfillSoftDeleteNull` + `firestore.indexes.example.json`.
-  Nested `runInFirestoreTransaction` joins the ambient handle on the same
-  backend and refuses to span backends.
+  Includes `backfillSoftDeleteNull` / `adminStreamBackfillSoftDeleteNull` +
+  `firestore.indexes.example.json`. Nested `runInFirestoreTransaction` joins
+  the ambient handle on the same backend and refuses to span backends.
+- Firestore P1 follow-ups: `firestoreIncrement` + write preconditions (P1-2),
+  `uniqueDocumentIdField` with boot-time refuse of composite unique (P1-3
+  tier 1), inequality `orderBy` reconcile (P1-5), WriteBatch `createMany` /
+  `deleteMany` (P1-6), and enforced 500-write transaction limit.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,17 @@ Per-package release notes live in `packages/*/CHANGELOG.md`.
   `FIRESTORE_BACKEND` DI export, `transactionFactories` + `options.ctx`
   threading, transactional duplicate-id → 409 mapping, and `limit()` on
   transactional queries. Contended RMW must use the callback API.
-- Firestore soft-delete server pushdown (issue #44 P1-4): materialize
-  explicit `null` on create only; default lists/counts use `field == null`.
+- Firestore soft-delete server pushdown (issue #44 P1-4): default lists/counts
+  use `field == null`, restoring `limit()` / aggregation. **Requires a data
+  backfill and composite indexes before deploy** — see the package CHANGELOG.
   Includes `backfillSoftDeleteNull` + `firestore.indexes.example.json`.
-  Nested `runInFirestoreTransaction` joins the ambient handle.
+  Nested `runInFirestoreTransaction` joins the ambient handle on the same
+  backend and refuses to span backends.
+
+### Changed
+
+- CI: `ci-pr-test` and `release-readiness` no longer filter on a `main` base,
+  so stacked pull requests are gated (including the Firestore emulator suite).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ Per-package release notes live in `packages/*/CHANGELOG.md`.
 
 ### Added
 
-- Firestore adapter transactions (issue #44 P1-1): `runInFirestoreTransaction`
-  (callback-scoped, retry-safe), `transactionFactories` + `options.ctx`
+- Firestore adapter transactions (issue #44 P1-1): `runInFirestoreTransaction` /
+  `FirestoreRepository.transaction` (callback-scoped, retry-safe),
+  `FIRESTORE_BACKEND` DI export, `transactionFactories` + `options.ctx`
   threading, transactional duplicate-id → 409 mapping, and `limit()` on
   transactional queries. Contended RMW must use the callback API.
+- Firestore soft-delete server pushdown (issue #44 P1-4): materialize
+  explicit `null` on create only; default lists/counts use `field == null`.
+  Includes `backfillSoftDeleteNull` + `firestore.indexes.example.json`.
+  Nested `runInFirestoreTransaction` joins the ambient handle.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Per-package release notes live in `packages/*/CHANGELOG.md`.
 
 ## [Unreleased]
 
+### Added
+
+- Firestore adapter transactions (issue #44 P1-1): `runInFirestoreTransaction`
+  (callback-scoped, retry-safe), `transactionFactories` + `options.ctx`
+  threading, transactional duplicate-id → 409 mapping, and `limit()` on
+  transactional queries. Contended RMW must use the callback API.
+
 ### Removed
 
 - **`SafeCrudContextInterceptor`** — upstream `@concepta/nestjs-crud`

--- a/packages/rockets-repository-firestore/CHANGELOG.md
+++ b/packages/rockets-repository-firestore/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+### Breaking — data migration required
+
+- **Soft-delete exclusion moved server-side (issue #44 P1-4).** Default
+  `find` / `count` now send `softDeleteField == null` to Firestore instead of
+  filtering in memory, which restores `limit()` and the `count()`
+  aggregation for every soft-deletable entity. Two consequences:
+  - **Existing documents that do not carry the field become invisible** to
+    default lists (Firestore equality never matches a missing field). Run
+    `backfillSoftDeleteNull` (or the Admin `stream()` + `BulkWriter` recipe in
+    the README) **before** deploying this version.
+  - Lists that combine soft delete with another predicate or `orderBy` now
+    need a **composite index**; without it Firestore returns
+    `FAILED_PRECONDITION`. See `firestore.indexes.example.json`. The emulator
+    does not validate indexes, so a green suite does not prove this.
+
+  The adapter writes the marker on `create`, on `upsert` that lands on a new
+  document, and on `replace` (carrying the previous state). `update` and
+  `upsert` over an existing document never invent it, so soft-deleted rows are
+  not resurrected.
+
 ### Added
 
 - **Transactions (issue #44 P1-1).** `FirestoreBackend.runTransaction` for
@@ -14,13 +34,10 @@
   `options.ctx` into the transaction. Transactional `create` maps duplicate
   ids to `FirestoreDuplicateIdException`; transactional queries push
   `limit()`.
-- Soft-delete server pushdown (issue #44 P1-4): create materializes
-  explicit `null`; default lists/counts use `field == null` on the server so
-  `limit()` / aggregation stay enabled. Update/upsert do **not** invent null
-  (avoids silent resurrection). Nested `runInFirestoreTransaction` joins the
-  ambient handle. Ships `backfillSoftDeleteNull` +
-  `firestore.indexes.example.json` for the migration/index work production
-  needs after this change.
+- Nested `runInFirestoreTransaction` joins the ambient handle on the same
+  backend and throws `FIRESTORE_TRANSACTION_BACKEND_MISMATCH` across
+  backends; the ambient handle is bound to its backend, so a repository on
+  another backend never joins it.
 - Full `WhereOperator` coverage (EQ, NE, comparisons, IN, NIN, null checks,
   string matchers, BETWEEN) with Firestore-native or post-filter execution.
 - OR support via `RepositoryAdapter.toDnf()`.

--- a/packages/rockets-repository-firestore/CHANGELOG.md
+++ b/packages/rockets-repository-firestore/CHANGELOG.md
@@ -33,11 +33,22 @@
   logs a one-time warning); every `do*` method threads ambient /
   `options.ctx` into the transaction. Transactional `create` maps duplicate
   ids to `FirestoreDuplicateIdException`; transactional queries push
-  `limit()`.
-- Nested `runInFirestoreTransaction` joins the ambient handle on the same
-  backend and throws `FIRESTORE_TRANSACTION_BACKEND_MISMATCH` across
-  backends; the ambient handle is bound to its backend, so a repository on
-  another backend never joins it.
+  `limit()`. Nested `runInFirestoreTransaction` joins the ambient handle on
+  the same backend and throws `FIRESTORE_TRANSACTION_BACKEND_MISMATCH`
+  across backends; the ambient handle is bound to its backend.
+- **Atomic increment / precondition (P1-2).** `firestoreIncrement(delta)`
+  sentinel + optional `FirestoreWritePrecondition` on `set`/`delete`;
+  `FirestoreRepository.increment(...)` helper.
+- **Deterministic document ids (P1-3 tier 1).** `uniqueDocumentIdField` /
+  single-column `uniqueConstraints`; composite unique refuses at boot.
+- **Inequality orderBy reconcile (P1-5).** First `orderBy` promoted to the
+  inequality field; mismatched caller order falls back to local sort
+  (no wrong server pagination).
+- **WriteBatch for createMany/deleteMany (P1-6).** Atomic batches of ≤500
+  outside transactions; sequential inside ambient txs. Enforced
+  `FIRESTORE_MAX_TRANSACTION_WRITES` (500) on transaction handles.
+- `adminStreamBackfillSoftDeleteNull` (BulkWriter stream) for large
+  collections; `backfillSoftDeleteNull` remains for small / in-memory.
 - Full `WhereOperator` coverage (EQ, NE, comparisons, IN, NIN, null checks,
   string matchers, BETWEEN) with Firestore-native or post-filter execution.
 - OR support via `RepositoryAdapter.toDnf()`.

--- a/packages/rockets-repository-firestore/CHANGELOG.md
+++ b/packages/rockets-repository-firestore/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## Unreleased
 
-### Release preparation
-
-- Package manifest set to `1.0.0-alpha.8`; registry publication is
-  pending.
-
 ### Added
 
+- **Transactions (issue #44 P1-1).** `FirestoreBackend.runTransaction` for
+  callback-shaped atomic units; `runInFirestoreTransaction` keeps the body
+  inside the SDK callback (retries re-execute); `transactionFactories`
+  registered from `forFeature` so `TransactionScope` / `transactional: true`
+  is supported; every `do*` method threads ambient / `options.ctx` into the
+  transaction. Contended RMW must use `runInFirestoreTransaction` — the
+  imperative bridge refuses Firestore retries (throws) instead of committing
+  an empty write set. Transactional `create` maps duplicate ids to
+  `FirestoreDuplicateIdException`; transactional queries push `limit()`.
 - Full `WhereOperator` coverage (EQ, NE, comparisons, IN, NIN, null checks,
   string matchers, BETWEEN) with Firestore-native or post-filter execution.
 - OR support via `RepositoryAdapter.toDnf()`.
@@ -18,6 +22,11 @@
 - Soft delete / restore when `dateRemoved` or `deletedAt` exists on the entity.
 - `withDeleted` on find options.
 - Exported `ensureFirebaseAdminApp()` for shared Admin bootstrap with auth.
+
+### Release preparation
+
+- Package manifest set to `1.0.0-alpha.8`; registry publication is
+  pending.
 
 ### Changed
 

--- a/packages/rockets-repository-firestore/CHANGELOG.md
+++ b/packages/rockets-repository-firestore/CHANGELOG.md
@@ -18,9 +18,11 @@
     does not validate indexes, so a green suite does not prove this.
 
   The adapter writes the marker on `create`, on `upsert` that lands on a new
-  document, and on `replace` (carrying the previous state). `update` and
-  `upsert` over an existing document never invent it, so soft-deleted rows are
-  not resurrected.
+  document, and on `replace` when the document is missing / legacy. `replace`
+  preserves deletion when the loaded entity (or a live read for hand-built
+  entities / `dateRemoved: undefined`) carries the marker. `update` and
+  `upsert` over an existing document never invent it, so soft-deleted rows
+  are not resurrected.
 
 ### Added
 
@@ -38,15 +40,32 @@
   across backends; the ambient handle is bound to its backend.
 - **Atomic increment / precondition (P1-2).** `firestoreIncrement(delta)`
   sentinel + optional `FirestoreWritePrecondition` on `set`/`delete`;
-  `FirestoreRepository.increment(...)` helper.
-- **Deterministic document ids (P1-3 tier 1).** `uniqueDocumentIdField` /
-  single-column `uniqueConstraints`; composite unique refuses at boot.
-- **Inequality orderBy reconcile (P1-5).** First `orderBy` promoted to the
-  inequality field; mismatched caller order falls back to local sort
-  (no wrong server pagination).
+  `FirestoreRepository.increment(...)` writes only the counter field
+  (defaults to `exists: true`, returns `void`; pass
+  `{ precondition: undefined }` to opt out). `updateWithPrecondition`
+  exposes CAS without casting. Public typed exceptions:
+  `FirestoreInvalidPreconditionException`,
+  `FirestoreInvalidDocumentIdException`,
+  `FirestoreBatchWriteLimitExceededException`.
+- **Deterministic document ids (P1-3 tier 1).** Manual opt-in via
+  `uniqueDocumentIdField` or single-column `uniqueConstraints` on
+  `forFeature` registration (composite unique refuses at boot). Document ids
+  are validated against Firestore rules (UTF-8 byte length, `.` / `..`,
+  `__*__`, `/`). Zod / `db.unique` schema metadata is **not** auto-wired yet
+  — `f.string({ unique: true })` is ignored until a follow-up wires schema →
+  provider options.
+- **Inequality orderBy reconcile (P1-5).** Every inequality field is
+  promoted ahead of the caller's `orderBy` when the leading set does not
+  already contain them (any order among inequalities keeps `limit()`
+  pushdown); otherwise local sort (full matching set read).
 - **WriteBatch for createMany/deleteMany (P1-6).** Atomic batches of ≤500
   outside transactions; sequential inside ambient txs. Enforced
-  `FIRESTORE_MAX_TRANSACTION_WRITES` (500) on transaction handles.
+  `FIRESTORE_MAX_TRANSACTION_WRITES` / `FIRESTORE_MAX_BATCH_WRITES` (500).
+  Multi-create batch duplicate collisions report document id `"unknown"`
+  (Admin does not name the colliding op). Soft-deletable reads after a write
+  in a transaction throw `FirestoreTransactionReadAfterWriteException`.
+  Transactional `createMany` hoists existence reads before writes so N≥2
+  does not hit read-after-write.
 - `adminStreamBackfillSoftDeleteNull` (BulkWriter stream) for large
   collections; `backfillSoftDeleteNull` remains for small / in-memory.
 - Full `WhereOperator` coverage (EQ, NE, comparisons, IN, NIN, null checks,

--- a/packages/rockets-repository-firestore/CHANGELOG.md
+++ b/packages/rockets-repository-firestore/CHANGELOG.md
@@ -5,14 +5,22 @@
 ### Added
 
 - **Transactions (issue #44 P1-1).** `FirestoreBackend.runTransaction` for
-  callback-shaped atomic units; `runInFirestoreTransaction` keeps the body
-  inside the SDK callback (retries re-execute); `transactionFactories`
-  registered from `forFeature` so `TransactionScope` / `transactional: true`
-  is supported; every `do*` method threads ambient / `options.ctx` into the
-  transaction. Contended RMW must use `runInFirestoreTransaction` — the
-  imperative bridge refuses Firestore retries (throws) instead of committing
-  an empty write set. Transactional `create` maps duplicate ids to
-  `FirestoreDuplicateIdException`; transactional queries push `limit()`.
+  callback-shaped atomic units; `runInFirestoreTransaction` /
+  `FirestoreRepository.transaction` keep the body inside the SDK callback
+  (retries re-execute); `FIRESTORE_BACKEND` is exported from `forFeature`;
+  `transactionFactories` registered so `TransactionScope` /
+  `transactional: true` is supported (imperative bridge refuses retries and
+  logs a one-time warning); every `do*` method threads ambient /
+  `options.ctx` into the transaction. Transactional `create` maps duplicate
+  ids to `FirestoreDuplicateIdException`; transactional queries push
+  `limit()`.
+- Soft-delete server pushdown (issue #44 P1-4): create materializes
+  explicit `null`; default lists/counts use `field == null` on the server so
+  `limit()` / aggregation stay enabled. Update/upsert do **not** invent null
+  (avoids silent resurrection). Nested `runInFirestoreTransaction` joins the
+  ambient handle. Ships `backfillSoftDeleteNull` +
+  `firestore.indexes.example.json` for the migration/index work production
+  needs after this change.
 - Full `WhereOperator` coverage (EQ, NE, comparisons, IN, NIN, null checks,
   string matchers, BETWEEN) with Firestore-native or post-filter execution.
 - OR support via `RepositoryAdapter.toDnf()`.

--- a/packages/rockets-repository-firestore/README.md
+++ b/packages/rockets-repository-firestore/README.md
@@ -71,15 +71,22 @@ a Firestore retry (throws `FIRESTORE_TRANSACTION_RETRY_UNSUPPORTED`) instead of
 committing an empty write set. The bridge logs a one-time warning on first use.
 Do not use it for hot paths that expect retries.
 
-Firestore limits a single transaction to **500 writes**; the adapter does not
-split oversized units. Inside a transaction there is no `count()` aggregation
-— `count` / `findAndCount` read every matching document and hold locks on it,
-so avoid unbounded counts in a transactional path.
+Firestore limits a single transaction to **500 writes** and refuses the
+501st write with `FIRESTORE_TRANSACTION_WRITE_LIMIT_EXCEEDED`. Inside a
+transaction there is no `count()` aggregation — `count` / `findAndCount`
+read every matching document and hold locks on it, so avoid unbounded counts
+in a transactional path.
 
-On a **soft-deletable** entity, `create` and `upsert` read the document before
-writing (to decide the soft-delete marker without resurrecting a deleted row).
-Firestore requires all reads before all writes inside a transaction, so call
-them before any write in the same transactional unit.
+On a **soft-deletable** entity, `create` and `upsert` (and `replace` when the
+caller omits the soft-delete field) read the document before writing so a
+deleted row is not resurrected. Firestore requires all reads before all
+writes inside a transaction — call those ops before any write in the same
+unit, or the adapter throws `FIRESTORE_TRANSACTION_READ_AFTER_WRITE`.
+
+Outside a transaction, soft-deletable `upsert` is still two round trips
+(read then set). A concurrent soft-delete between them can resurrect the
+row; wrap contended upserts in `repo.transaction()` / `runInFirestoreTransaction`
+when that race matters.
 
 Nesting `runInFirestoreTransaction` (or `repo.transaction()`) on the same
 backend joins the ambient transaction; nesting across two different backends
@@ -88,13 +95,37 @@ span databases. A repository bound to another backend does not join the
 ambient handle — its writes go through its own backend, outside that
 transaction.
 
-Atomic `createMany` / `deleteMany` (WriteBatch) are still follow-ups
-(issue #44 P1-6). Soft-delete exclusion is pushed server-side as
-`dateRemoved == null` (P1-4); **create** materializes an explicit `null` on
-write. Update/upsert/replace never invent that null (would resurrect
-soft-deleted docs). Legacy docs that omit the field need a one-time
-`backfillSoftDeleteNull` (or Admin stream) before they appear in default
-lists.
+`createMany` / `deleteMany` use atomic `WriteBatch` (≤500 ops per batch)
+outside transactions; inside a transaction they stay sequential on the ambient
+handle. Soft-delete exclusion is pushed server-side as `dateRemoved == null`
+(P1-4). Use `firestoreIncrement(delta)` / `repo.increment(...)` for counters
+without a full RMW transaction — `increment` writes only the counter field,
+returns `void`, and defaults to `exists: true` (missing documents fail with
+`FirestorePreconditionFailedException`). Pass `{ precondition: undefined }`
+to opt out of the exists check. Use `updateWithPrecondition(...)` for
+exists-guarded / `lastUpdateTime` updates (document `updateTime` is not yet
+exposed on entity reads — `lastUpdateTime` CAS requires a time you already
+hold). Inequality queries promote every inequality field ahead of the
+requested `orderBy` when the leading set does not already contain them
+(any order among inequalities keeps `limit()` pushdown, but each order
+needs its own composite index). When promotion changes the leading set,
+`limit()` is **not** pushed and the matching set is read then sorted
+client-side (cost scales with matches, not the page size).
+
+`update` without a precondition uses `set({ merge: true })` (nested maps
+deep-merge). `updateWithPrecondition` uses Admin `update()` (map-valued
+fields are replaced wholesale; dotted keys are field paths).
+
+Tier-1 uniqueness: set `uniqueDocumentIdField` (or a single-column
+`uniqueConstraints` entry) on the `forFeature` / entity registration row —
+composite unique refuses at boot. Zod / `db.unique` schema metadata is not
+auto-wired yet; `f.string({ unique: true })` alone does nothing.
+
+`createMany` chunks larger than 500 are **not** atomic across chunks.
+
+Legacy docs that omit the soft-delete field need a one-time
+`backfillSoftDeleteNull` or `adminStreamBackfillSoftDeleteNull` before they
+appear in default lists.
 
 Default lists that combine soft-delete with other filters / `orderBy` need
 **composite indexes**. The emulator does not validate indexes — production
@@ -228,8 +259,11 @@ naming both supported column names.
 The adapter materializes an explicit `null` for that field so default lists can
 use a server-side `== null` filter (and keep `limit` / `count` on Firestore):
 on `create`, on an `upsert` that lands on a **new** document, and on `replace`
-(which carries the previous state so a live row stays live and a deleted row
-stays deleted). `update` and `upsert` over an **existing** document never
+when the document is missing or legacy (no field yet). `replace` carries the
+soft-delete value from the loaded entity when present; if the entity is
+hand-built (`{ id }` only) or the DTO passes `dateRemoved: undefined`,
+`replace` reads the live document and preserves a soft-deleted marker instead
+of inventing `null`. `update` and `upsert` over an **existing** document never
 invent it — under `merge: true` that would resurrect soft-deleted documents.
 
 Documents written outside the adapter without the field will not appear in
@@ -300,10 +334,9 @@ Document-id `IN` queries accept at most 500 ids and use one Admin SDK `getAll`
 request. The direct-document path fetches all requested ids before applying
 `skip` and `take`, so a page limit does not reduce document reads.
 
-`createMany()` writes documents sequentially and is not atomic: if a later
-document id already exists, earlier documents from the same call remain
-created. Atomic batched creation is intentionally deferred to a future backend
-contract change.
+`createMany` / `deleteMany` commit through `WriteBatch` (atomic per ≤500-op
+chunk). Chunks larger than 500 are committed sequentially — a later chunk
+failure leaves earlier chunks applied.
 
 ---
 

--- a/packages/rockets-repository-firestore/README.md
+++ b/packages/rockets-repository-firestore/README.md
@@ -51,9 +51,29 @@ Other entities continue on the default adapter (TypeORM, in most apps).
 
 ### When NOT to use this package
 
-- You need ACID transactions across multiple entities — stay on a SQL adapter
-  for cross-entity transactional flows.
+- You need SQL-style relational joins or multi-field unique constraints that
+  cannot map to a document id / uniqueness-index collection — see issue #44
+  "Honest limits".
 - You only want SQL — install `@concepta/rockets-repository-typeorm` instead.
+
+### Transactions
+
+Prefer `runInFirestoreTransaction(backend, async () => { … })` for contended
+read-modify-write (rate limits, leases, turn locks, idempotent enqueue). The
+body runs **inside** the SDK callback, so a contention retry re-executes it.
+Repository calls made during the callback automatically join the ambient
+transaction — no `{ ctx }` plumbing required.
+
+`TransactionScope.run(ctx, …)` with `{ ctx }` still works for uncontended
+multi-write units, but the imperative bridge **refuses** a Firestore retry
+(throws `FIRESTORE_TRANSACTION_RETRY_UNSUPPORTED`) instead of committing an
+empty write set. Do not use it for hot paths that expect retries.
+
+Firestore limits a single transaction to **500 writes**; the adapter does not
+split oversized units.
+
+Atomic `createMany` / `deleteMany` (WriteBatch) and soft-delete server-side
+pushdown are still follow-ups (issue #44 P1-4 / P1-6).
 
 ---
 

--- a/packages/rockets-repository-firestore/README.md
+++ b/packages/rockets-repository-firestore/README.md
@@ -58,22 +58,35 @@ Other entities continue on the default adapter (TypeORM, in most apps).
 
 ### Transactions
 
-Prefer `runInFirestoreTransaction(backend, async () => { … })` for contended
-read-modify-write (rate limits, leases, turn locks, idempotent enqueue). The
-body runs **inside** the SDK callback, so a contention retry re-executes it.
-Repository calls made during the callback automatically join the ambient
-transaction — no `{ ctx }` plumbing required.
+Prefer `FirestoreRepository.transaction(async () => { … })` (or
+`runInFirestoreTransaction(backend, …)` / inject `FIRESTORE_BACKEND`) for
+contended read-modify-write (rate limits, leases, turn locks, idempotent
+enqueue). The body runs **inside** the SDK callback, so a contention retry
+re-executes it. Repository calls made during the callback automatically join
+the ambient transaction — no `{ ctx }` plumbing required.
 
-`TransactionScope.run(ctx, …)` with `{ ctx }` still works for uncontended
-multi-write units, but the imperative bridge **refuses** a Firestore retry
-(throws `FIRESTORE_TRANSACTION_RETRY_UNSUPPORTED`) instead of committing an
-empty write set. Do not use it for hot paths that expect retries.
+`TransactionScope.run(ctx, …)` with `{ ctx }` / `transactional: true` still
+works for uncontended multi-write units, but the imperative bridge **refuses**
+a Firestore retry (throws `FIRESTORE_TRANSACTION_RETRY_UNSUPPORTED`) instead of
+committing an empty write set. The bridge logs a one-time warning on first use.
+Do not use it for hot paths that expect retries.
 
 Firestore limits a single transaction to **500 writes**; the adapter does not
 split oversized units.
 
-Atomic `createMany` / `deleteMany` (WriteBatch) and soft-delete server-side
-pushdown are still follow-ups (issue #44 P1-4 / P1-6).
+Atomic `createMany` / `deleteMany` (WriteBatch) are still follow-ups
+(issue #44 P1-6). Soft-delete exclusion is pushed server-side as
+`dateRemoved == null` (P1-4); **create** materializes an explicit `null` on
+write. Update/upsert/replace never invent that null (would resurrect
+soft-deleted docs). Legacy docs that omit the field need a one-time
+`backfillSoftDeleteNull` (or Admin stream) before they appear in default
+lists.
+
+Default lists that combine soft-delete with other filters / `orderBy` need
+**composite indexes**. The emulator does not validate indexes — production
+returns `FAILED_PRECONDITION` without them. Copy
+[`firestore.indexes.example.json`](./firestore.indexes.example.json) into your
+app's `firestore.indexes.json` and replace collection / field paths.
 
 ---
 
@@ -198,6 +211,64 @@ override — name the column `dateRemoved` or `deletedAt` on the entity class.
 If neither name is present, `delete()` calls throw at runtime with a message
 naming both supported column names.
 
+On **create**, the adapter materializes an explicit `null` for that field when
+absent so default lists can use a server-side `== null` filter (and keep
+`limit` / `count` on Firestore). Update / upsert / replace never invent that
+null — that would resurrect soft-deleted documents under `merge: true`.
+
+Documents written outside the adapter without the field will not appear in
+default lists until backfilled:
+
+```ts
+import {
+  backfillSoftDeleteNull,
+  InMemoryFirestoreBackend, // or inject FIRESTORE_BACKEND
+} from '@concepta/rockets-repository-firestore';
+
+await backfillSoftDeleteNull({
+  backend,
+  collection: 'widgets',
+  softDeleteField: 'dateRemoved',
+});
+```
+
+For large production collections, stream with the Admin SDK instead of the
+helper (which loads the collection via `queryBranch`):
+
+```ts
+import { getFirestore } from 'firebase-admin/firestore';
+
+const db = getFirestore();
+const writer = db.bulkWriter();
+for await (const doc of db.collection('widgets').stream()) {
+  if (!Object.prototype.hasOwnProperty.call(doc.data(), 'dateRemoved')) {
+    writer.set(doc.ref, { dateRemoved: null }, { merge: true });
+  }
+}
+await writer.close();
+```
+
+### Composite indexes (required in production)
+
+Any query that applies soft-delete exclusion **and** another equality /
+`orderBy` needs a composite index. Example shape (see
+`firestore.indexes.example.json`):
+
+```json
+{
+  "collectionGroup": "widgets",
+  "queryScope": "COLLECTION",
+  "fields": [
+    { "fieldPath": "dateRemoved", "order": "ASCENDING" },
+    { "fieldPath": "userId", "order": "ASCENDING" },
+    { "fieldPath": "dateCreated", "order": "DESCENDING" }
+  ]
+}
+```
+
+Deploy with `firebase deploy --only firestore:indexes`. The emulator suite
+stays green without indexes; production fails with `FAILED_PRECONDITION`.
+
 ### Local query parity
 
 The in-memory backend and Admin SDK direct-document/post-filter paths match
@@ -235,6 +306,8 @@ contract change.
 | Symbol                                | Purpose                                               |
 | ------------------------------------- | ----------------------------------------------------- |
 | `ensureFirebaseAdminApp(packageRoot)` | App-level Admin singleton (call from auth bootstrap). |
+| `FIRESTORE_BACKEND`                   | DI token for the shared backend from `forFeature`.    |
+| `backfillSoftDeleteNull(...)`         | Patch legacy docs missing the soft-delete field.      |
 | `InMemoryFirestoreBackend`            | Explicit test double — not selected by env vars.      |
 
 ---

--- a/packages/rockets-repository-firestore/README.md
+++ b/packages/rockets-repository-firestore/README.md
@@ -72,7 +72,21 @@ committing an empty write set. The bridge logs a one-time warning on first use.
 Do not use it for hot paths that expect retries.
 
 Firestore limits a single transaction to **500 writes**; the adapter does not
-split oversized units.
+split oversized units. Inside a transaction there is no `count()` aggregation
+— `count` / `findAndCount` read every matching document and hold locks on it,
+so avoid unbounded counts in a transactional path.
+
+On a **soft-deletable** entity, `create` and `upsert` read the document before
+writing (to decide the soft-delete marker without resurrecting a deleted row).
+Firestore requires all reads before all writes inside a transaction, so call
+them before any write in the same transactional unit.
+
+Nesting `runInFirestoreTransaction` (or `repo.transaction()`) on the same
+backend joins the ambient transaction; nesting across two different backends
+throws `FIRESTORE_TRANSACTION_BACKEND_MISMATCH`, since a transaction cannot
+span databases. A repository bound to another backend does not join the
+ambient handle — its writes go through its own backend, outside that
+transaction.
 
 Atomic `createMany` / `deleteMany` (WriteBatch) are still follow-ups
 (issue #44 P1-6). Soft-delete exclusion is pushed server-side as
@@ -211,10 +225,12 @@ override — name the column `dateRemoved` or `deletedAt` on the entity class.
 If neither name is present, `delete()` calls throw at runtime with a message
 naming both supported column names.
 
-On **create**, the adapter materializes an explicit `null` for that field when
-absent so default lists can use a server-side `== null` filter (and keep
-`limit` / `count` on Firestore). Update / upsert / replace never invent that
-null — that would resurrect soft-deleted documents under `merge: true`.
+The adapter materializes an explicit `null` for that field so default lists can
+use a server-side `== null` filter (and keep `limit` / `count` on Firestore):
+on `create`, on an `upsert` that lands on a **new** document, and on `replace`
+(which carries the previous state so a live row stays live and a deleted row
+stays deleted). `update` and `upsert` over an **existing** document never
+invent it — under `merge: true` that would resurrect soft-deleted documents.
 
 Documents written outside the adapter without the field will not appear in
 default lists until backfilled:

--- a/packages/rockets-repository-firestore/firestore.indexes.example.json
+++ b/packages/rockets-repository-firestore/firestore.indexes.example.json
@@ -1,0 +1,23 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "YOUR_COLLECTION",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "dateRemoved", "order": "ASCENDING" },
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "dateCreated", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "YOUR_COLLECTION",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "deletedAt", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "updatedAt", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/packages/rockets-repository-firestore/package.json
+++ b/packages/rockets-repository-firestore/package.json
@@ -28,6 +28,7 @@
   },
   "files": [
     "dist/**/!(*.spec|*.e2e-spec|*.fixture).{js,d.ts}",
+    "firestore.indexes.example.json",
     "README.md",
     "LICENSE.txt",
     "CHANGELOG.md"

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-backend.emulator-spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-backend.emulator-spec.ts
@@ -13,6 +13,7 @@ import {
 import { AdminFirestoreBackend } from '../backends/admin-firestore.backend';
 import { InMemoryFirestoreBackend } from '../backends/in-memory-firestore.backend';
 import { FirestoreDuplicateIdException } from '../exceptions/firestore-duplicate-id.exception';
+import { FirestorePreconditionFailedException } from '../exceptions/firestore-precondition-failed.exception';
 import type { FirestoreBackend } from '../interfaces/firestore-backend.interface';
 import type { FirestoreBranchQueryOptions } from '../interfaces/firestore-backend.interface';
 import { FirestoreRepositoryModule } from '../firestore-repository.module';
@@ -434,5 +435,125 @@ describe('Firestore repository ambient transaction (emulator)', () => {
       await repo.findOne({ where: Where.eq('id', 'counter') }),
     ).toMatchObject({ value: 10 });
     expect(bodyRuns).toBeGreaterThanOrEqual(10);
+  });
+
+  it('repo.increment: sibling fields survive and missing docs fail closed', async () => {
+    class CounterEntity {
+      id!: string;
+      name!: string;
+      value!: number;
+    }
+
+    const collection = `tx-repo-increment-${randomUUID()}`;
+    const wired = await Test.createTestingModule({
+      imports: [
+        RepositoryModule.forRoot({}),
+        RepositoryModule.forFeature({
+          module: {
+            name: FirestoreRepositoryModule.name,
+            forFeature: (entities: RepositoryProviderOptions[]) =>
+              FirestoreRepositoryModule.forFeature(
+                entities.map((entity) => ({
+                  key: entity.key,
+                  entity: entity.entity,
+                  collection,
+                })),
+                { backend: admin },
+              ),
+          },
+          entities: [{ key: 'counter', entity: CounterEntity }],
+        }),
+      ],
+    }).compile();
+
+    const repo = wired.get<RepositoryInterface<CounterEntity>>(
+      getDynamicRepositoryToken('counter'),
+    );
+    expect(isFirestoreRepository(repo)).toBe(true);
+    if (!isFirestoreRepository(repo)) {
+      throw new Error('expected FirestoreRepository');
+    }
+
+    await expect(
+      repo.increment({ id: 'missing', name: 'A', value: 0 }, 'value', 1),
+    ).rejects.toBeInstanceOf(FirestorePreconditionFailedException);
+
+    const created = await repo.create({ id: 'c1', name: 'A', value: 5 });
+    await admin.set(collection, 'c1', { name: 'B' }, true);
+    await repo.increment(created, 'value', 3);
+
+    expect(await admin.get(collection, 'c1')).toEqual({
+      id: 'c1',
+      name: 'B',
+      value: 8,
+    });
+  });
+
+  it('Admin soft-delete: create/upsert/replace keep visibility rules', async () => {
+    class SoftWidgetEntity {
+      id!: string;
+      title!: string;
+      dateRemoved!: Date | null;
+    }
+
+    const collection = `soft-parity-${randomUUID()}`;
+    const wired = await Test.createTestingModule({
+      imports: [
+        RepositoryModule.forRoot({}),
+        RepositoryModule.forFeature({
+          module: {
+            name: FirestoreRepositoryModule.name,
+            forFeature: (entities: RepositoryProviderOptions[]) =>
+              FirestoreRepositoryModule.forFeature(
+                entities.map((entity) => ({
+                  key: entity.key,
+                  entity: entity.entity,
+                  collection,
+                  softDeleteField: 'dateRemoved',
+                })),
+                { backend: admin },
+              ),
+          },
+          entities: [{ key: 'soft-widget', entity: SoftWidgetEntity }],
+        }),
+      ],
+    }).compile();
+
+    const repo = wired.get<RepositoryInterface<SoftWidgetEntity>>(
+      getDynamicRepositoryToken('soft-widget'),
+    );
+
+    await repo.create({ id: 'live', title: 'Live' });
+    await expect(repo.find()).resolves.toEqual([
+      expect.objectContaining({ id: 'live', dateRemoved: null }),
+    ]);
+
+    await repo.upsert({ id: 'fresh', title: 'Fresh' });
+    await expect(
+      repo.findOne({ where: Where.eq('id', 'fresh') }),
+    ).resolves.toMatchObject({ dateRemoved: null });
+
+    const doomed = await repo.findOne({ where: Where.eq('id', 'live') });
+    await repo.softDelete(doomed!);
+    await expect(repo.find()).resolves.toEqual([
+      expect.objectContaining({ id: 'fresh' }),
+    ]);
+
+    await repo.replace({ id: 'live' } as SoftWidgetEntity, {
+      id: 'live',
+      title: 'Still gone',
+    });
+    await expect(repo.find()).resolves.toEqual([
+      expect.objectContaining({ id: 'fresh' }),
+    ]);
+    await expect(repo.find({ withDeleted: true })).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'live',
+          title: 'Still gone',
+          dateRemoved: expect.any(Date),
+        }),
+      ]),
+    );
   });
 });

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-backend.emulator-spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-backend.emulator-spec.ts
@@ -4,6 +4,7 @@ import { deleteApp, getApps, initializeApp } from 'firebase-admin/app';
 
 import { AdminFirestoreBackend } from '../backends/admin-firestore.backend';
 import { InMemoryFirestoreBackend } from '../backends/in-memory-firestore.backend';
+import { FirestoreDuplicateIdException } from '../exceptions/firestore-duplicate-id.exception';
 import type { FirestoreBackend } from '../interfaces/firestore-backend.interface';
 import type { FirestoreBranchQueryOptions } from '../interfaces/firestore-backend.interface';
 
@@ -91,5 +92,120 @@ describe('Firestore backend emulator parity', () => {
       'map-code-point-first',
       'map-code-point-second',
     ]);
+  });
+});
+
+describe('Firestore backend emulator transactions', () => {
+  const admin = new AdminFirestoreBackend();
+  const memory = new InMemoryFirestoreBackend();
+
+  beforeAll(() => {
+    if (!process.env.FIRESTORE_EMULATOR_HOST) {
+      throw new Error(
+        'Run this suite with `corepack yarn test:firestore-emulator`.',
+      );
+    }
+    if (getApps().length === 0) initializeApp({ projectId: 'demo-rockets' });
+  });
+
+  afterAll(async () => {
+    for (const app of getApps()) await deleteApp(app);
+  });
+
+  for (const [label, backend] of [
+    ['admin', admin],
+    ['memory', memory],
+  ] as const) {
+    it(`${label}: runTransaction commits multi-doc writes atomically`, async () => {
+      const collection = `tx-commit-${label}-${randomUUID()}`;
+      await backend.create(collection, 'a', { id: 'a', balance: 100 });
+      await backend.create(collection, 'b', { id: 'b', balance: 0 });
+
+      await backend.runTransaction(async (tx) => {
+        const a = await tx.get(collection, 'a');
+        const b = await tx.get(collection, 'b');
+        await tx.set(collection, 'a', { id: 'a', balance: 75 }, false);
+        await tx.set(collection, 'b', { id: 'b', balance: 25 }, false);
+        expect(a?.balance).toBe(100);
+        expect(b?.balance).toBe(0);
+      });
+
+      expect(await backend.get(collection, 'a')).toMatchObject({ balance: 75 });
+      expect(await backend.get(collection, 'b')).toMatchObject({ balance: 25 });
+    });
+
+    it(`${label}: runTransaction rolls back on throw`, async () => {
+      const collection = `tx-rb-${label}-${randomUUID()}`;
+      await backend.create(collection, 'a', { id: 'a', balance: 100 });
+
+      await expect(
+        backend.runTransaction(async (tx) => {
+          await tx.set(collection, 'a', { id: 'a', balance: 0 }, false);
+          throw new Error('abort');
+        }),
+      ).rejects.toThrow('abort');
+
+      expect(await backend.get(collection, 'a')).toMatchObject({
+        balance: 100,
+      });
+    });
+
+    it(`${label}: transactional create maps duplicate id to FirestoreDuplicateIdException`, async () => {
+      const collection = `tx-dup-${label}-${randomUUID()}`;
+      await backend.create(collection, 'same', { id: 'same', v: 1 });
+
+      await expect(
+        backend.runTransaction(async (tx) => {
+          await tx.create(collection, 'same', { id: 'same', v: 2 });
+        }),
+      ).rejects.toBeInstanceOf(FirestoreDuplicateIdException);
+    });
+
+    it(`${label}: transactional queryBranch respects take/limit`, async () => {
+      const collection = `tx-limit-${label}-${randomUUID()}`;
+      for (let i = 0; i < 5; i += 1) {
+        await backend.create(collection, `row-${i}`, {
+          id: `row-${i}`,
+          rank: i,
+        });
+      }
+
+      const rows = await backend.runTransaction(async (tx) =>
+        tx.queryBranch(collection, {
+          branch: { filters: [], postFilters: [] },
+          orderBy: [{ field: 'rank', direction: 'asc' }],
+          take: 2,
+        }),
+      );
+
+      expect(rows.map((row) => row.id)).toEqual(['row-0', 'row-1']);
+    });
+  }
+
+  it('admin: concurrent create of the same id yields exactly one winner', async () => {
+    const collection = `tx-race-${randomUUID()}`;
+    const results = await Promise.allSettled(
+      Array.from({ length: 8 }, () =>
+        admin.runTransaction(async (tx) => {
+          await tx.create(collection, 'lease', {
+            id: 'lease',
+            owner: randomUUID(),
+          });
+          return 'won';
+        }),
+      ),
+    );
+
+    const wins = results.filter((r) => r.status === 'fulfilled');
+    const losses = results.filter((r) => r.status === 'rejected');
+    expect(wins).toHaveLength(1);
+    expect(losses.length).toBeGreaterThan(0);
+    for (const loss of losses) {
+      expect(loss.status).toBe('rejected');
+      if (loss.status === 'rejected') {
+        expect(loss.reason).toBeInstanceOf(FirestoreDuplicateIdException);
+      }
+    }
+    expect(await admin.get(collection, 'lease')).not.toBeNull();
   });
 });

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-backend.emulator-spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-backend.emulator-spec.ts
@@ -208,4 +208,132 @@ describe('Firestore backend emulator transactions', () => {
     }
     expect(await admin.get(collection, 'lease')).not.toBeNull();
   });
+
+  it('admin: 10 contended writers incrementing one counter land on 10', async () => {
+    const collection = `tx-counter-${randomUUID()}`;
+    await admin.create(collection, 'counter', { id: 'counter', value: 0 });
+
+    let bodyRuns = 0;
+    await Promise.all(
+      Array.from({ length: 10 }, () =>
+        admin.runTransaction(async (tx) => {
+          bodyRuns += 1;
+          const row = await tx.get(collection, 'counter');
+          const value = typeof row?.value === 'number' ? row.value : 0;
+          await tx.set(
+            collection,
+            'counter',
+            { id: 'counter', value: value + 1 },
+            false,
+          );
+        }),
+      ),
+    );
+
+    expect(await admin.get(collection, 'counter')).toMatchObject({ value: 10 });
+    expect(bodyRuns).toBeGreaterThanOrEqual(10);
+  });
+
+  it('admin: contended multi-doc read-modify-write keeps both docs consistent', async () => {
+    const collection = `tx-multi-${randomUUID()}`;
+    await admin.create(collection, 'left', { id: 'left', value: 0 });
+    await admin.create(collection, 'right', { id: 'right', value: 0 });
+
+    const writers = 8;
+    await Promise.all(
+      Array.from({ length: writers }, () =>
+        admin.runTransaction(async (tx) => {
+          const left = await tx.get(collection, 'left');
+          const right = await tx.get(collection, 'right');
+          const leftValue = typeof left?.value === 'number' ? left.value : 0;
+          const rightValue = typeof right?.value === 'number' ? right.value : 0;
+          await tx.set(
+            collection,
+            'left',
+            { id: 'left', value: leftValue + 1 },
+            false,
+          );
+          await tx.set(
+            collection,
+            'right',
+            { id: 'right', value: rightValue + 1 },
+            false,
+          );
+        }),
+      ),
+    );
+
+    const left = await admin.get(collection, 'left');
+    const right = await admin.get(collection, 'right');
+    expect(left).toMatchObject({ value: writers });
+    expect(right).toMatchObject({ value: writers });
+  });
+
+  it('admin: lease takeover yields one winner and domain errors for losers', async () => {
+    class LeaseTakenError extends Error {
+      constructor() {
+        super('lease already taken');
+        this.name = 'LeaseTakenError';
+      }
+    }
+
+    const collection = `tx-lease-${randomUUID()}`;
+    const expiredAt = new Date(Date.now() - 60_000);
+    await admin.create(collection, 'lease', {
+      id: 'lease',
+      owner: 'stale',
+      expiresAt: expiredAt,
+    });
+
+    const results = await Promise.allSettled(
+      Array.from({ length: 6 }, (_, index) =>
+        admin.runTransaction(async (tx) => {
+          const lease = await tx.get(collection, 'lease');
+          const expiresAtRaw = lease?.expiresAt;
+          const expiresAtValue =
+            expiresAtRaw instanceof Date
+              ? expiresAtRaw.getTime()
+              : typeof expiresAtRaw === 'number'
+              ? expiresAtRaw
+              : 0;
+          const owner =
+            typeof lease?.owner === 'string' ? lease.owner : undefined;
+          const worker = `worker-${index}`;
+          if (
+            owner !== undefined &&
+            owner !== worker &&
+            expiresAtValue > Date.now()
+          ) {
+            throw new LeaseTakenError();
+          }
+          await tx.set(
+            collection,
+            'lease',
+            {
+              id: 'lease',
+              owner: worker,
+              expiresAt: new Date(Date.now() + 60_000),
+            },
+            false,
+          );
+          return worker;
+        }),
+      ),
+    );
+
+    const wins = results.filter((result) => result.status === 'fulfilled');
+    const losses = results.filter((result) => result.status === 'rejected');
+    expect(wins).toHaveLength(1);
+    expect(losses).toHaveLength(5);
+    for (const loss of losses) {
+      expect(loss.status).toBe('rejected');
+      if (loss.status === 'rejected') {
+        expect(loss.reason).toBeInstanceOf(LeaseTakenError);
+      }
+    }
+
+    const lease = await admin.get(collection, 'lease');
+    expect(typeof lease?.owner).toBe('string');
+    expect(String(lease?.owner).startsWith('worker-')).toBe(true);
+  });
 });

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-backend.emulator-spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-backend.emulator-spec.ts
@@ -171,6 +171,20 @@ describe('Firestore backend emulator transactions', () => {
       ).rejects.toBeInstanceOf(FirestoreDuplicateIdException);
     });
 
+    it(`${label}: transactional create after a write is rejected`, async () => {
+      const collection = `tx-read-order-${label}-${randomUUID()}`;
+
+      await expect(
+        backend.runTransaction(async (tx) => {
+          await tx.set(collection, 'a', { id: 'a', v: 1 }, false);
+          await tx.create(collection, 'b', { id: 'b', v: 2 });
+        }),
+      ).rejects.toThrow();
+
+      expect(await backend.get(collection, 'a')).toBeNull();
+      expect(await backend.get(collection, 'b')).toBeNull();
+    });
+
     it(`${label}: transactional queryBranch respects take/limit`, async () => {
       const collection = `tx-limit-${label}-${randomUUID()}`;
       for (let i = 0; i < 5; i += 1) {

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-backend.emulator-spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-backend.emulator-spec.ts
@@ -1,12 +1,22 @@
 import { randomUUID } from 'node:crypto';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { deleteApp, getApps, initializeApp } from 'firebase-admin/app';
+import { Test } from '@nestjs/testing';
+import {
+  getDynamicRepositoryToken,
+  RepositoryModule,
+  Where,
+  type RepositoryInterface,
+  type RepositoryProviderOptions,
+} from '@concepta/nestjs-repository';
 
 import { AdminFirestoreBackend } from '../backends/admin-firestore.backend';
 import { InMemoryFirestoreBackend } from '../backends/in-memory-firestore.backend';
 import { FirestoreDuplicateIdException } from '../exceptions/firestore-duplicate-id.exception';
 import type { FirestoreBackend } from '../interfaces/firestore-backend.interface';
 import type { FirestoreBranchQueryOptions } from '../interfaces/firestore-backend.interface';
+import { FirestoreRepositoryModule } from '../firestore-repository.module';
+import { isFirestoreRepository } from '../repository/firestore-repository';
 
 describe('Firestore backend emulator parity', () => {
   const collection = `parity-${randomUUID()}`;
@@ -335,5 +345,80 @@ describe('Firestore backend emulator transactions', () => {
     const lease = await admin.get(collection, 'lease');
     expect(typeof lease?.owner).toBe('string');
     expect(String(lease?.owner).startsWith('worker-')).toBe(true);
+  });
+});
+
+describe('Firestore repository ambient transaction (emulator)', () => {
+  const admin = new AdminFirestoreBackend();
+
+  beforeAll(() => {
+    if (!process.env.FIRESTORE_EMULATOR_HOST) {
+      throw new Error(
+        'Run this suite with `corepack yarn test:firestore-emulator`.',
+      );
+    }
+    if (getApps().length === 0) initializeApp({ projectId: 'demo-rockets' });
+  });
+
+  afterAll(async () => {
+    for (const app of getApps()) await deleteApp(app);
+  });
+
+  it('repo.transaction: 10 contended writers incrementing one counter land on 10', async () => {
+    class CounterEntity {
+      id!: string;
+      value!: number;
+    }
+
+    const collection = `tx-repo-counter-${randomUUID()}`;
+    const wired = await Test.createTestingModule({
+      imports: [
+        RepositoryModule.forRoot({}),
+        RepositoryModule.forFeature({
+          module: {
+            name: FirestoreRepositoryModule.name,
+            forFeature: (entities: RepositoryProviderOptions[]) =>
+              FirestoreRepositoryModule.forFeature(
+                entities.map((entity) => ({
+                  key: entity.key,
+                  entity: entity.entity,
+                  collection,
+                })),
+                { backend: admin },
+              ),
+          },
+          entities: [{ key: 'counter', entity: CounterEntity }],
+        }),
+      ],
+    }).compile();
+
+    const repo = wired.get<RepositoryInterface<CounterEntity>>(
+      getDynamicRepositoryToken('counter'),
+    );
+    expect(isFirestoreRepository(repo)).toBe(true);
+    if (!isFirestoreRepository(repo)) {
+      throw new Error('expected FirestoreRepository');
+    }
+
+    await repo.create({ id: 'counter', value: 0 });
+
+    let bodyRuns = 0;
+    await Promise.all(
+      Array.from({ length: 10 }, () =>
+        repo.transaction(async () => {
+          bodyRuns += 1;
+          const row = await repo.findOne({
+            where: Where.eq('id', 'counter'),
+          });
+          const value = row?.value ?? 0;
+          await repo.update(row!, { value: value + 1 });
+        }),
+      ),
+    );
+
+    expect(
+      await repo.findOne({ where: Where.eq('id', 'counter') }),
+    ).toMatchObject({ value: 10 });
+    expect(bodyRuns).toBeGreaterThanOrEqual(10);
   });
 });

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-batch-write-limit.spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-batch-write-limit.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { InMemoryFirestoreBackend } from '../backends/in-memory-firestore.backend';
+import { FIRESTORE_MAX_BATCH_WRITES } from '../constants/firestore-transaction.constants';
+import { FirestoreBatchWriteLimitExceededException } from '../exceptions/firestore-batch-write-limit-exceeded.exception';
+import { FirestorePreconditionFailedException } from '../exceptions/firestore-precondition-failed.exception';
+import type { FirestoreBatchOperation } from '../interfaces/firestore-backend.interface';
+
+function overLimitCreates(): FirestoreBatchOperation[] {
+  return Array.from({ length: FIRESTORE_MAX_BATCH_WRITES + 1 }, (_, i) => ({
+    op: 'create' as const,
+    collection: 'batch-limit',
+    id: `row-${i}`,
+    data: { id: `row-${i}` },
+  }));
+}
+
+describe('WriteBatch 500-op limit', () => {
+  it('in-memory backend throws FirestoreBatchWriteLimitExceededException', async () => {
+    const backend = new InMemoryFirestoreBackend();
+    await expect(backend.writeBatch(overLimitCreates())).rejects.toMatchObject({
+      errorCode: 'FIRESTORE_BATCH_WRITE_LIMIT_EXCEEDED',
+    });
+    await expect(backend.writeBatch(overLimitCreates())).rejects.toBeInstanceOf(
+      FirestoreBatchWriteLimitExceededException,
+    );
+  });
+
+  it('rejects a stale lastUpdateTime precondition', async () => {
+    const backend = new InMemoryFirestoreBackend();
+    await backend.create('cas-time', 'row-1', { id: 'row-1', value: 1 });
+    await expect(
+      backend.set('cas-time', 'row-1', { value: 2 }, true, {
+        lastUpdateTime: new Date(0),
+      }),
+    ).rejects.toBeInstanceOf(FirestorePreconditionFailedException);
+  });
+});

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-deterministic-id.spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-deterministic-id.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { FirestoreInvalidDocumentIdException } from '../exceptions/firestore-invalid-document-id.exception';
+import { deriveFirestoreDocumentId } from '../utils/firestore-deterministic-id';
+
+describe('deriveFirestoreDocumentId', () => {
+  it('passes through a safe document id', () => {
+    expect(deriveFirestoreDocumentId('user-123')).toBe('user-123');
+  });
+
+  it('rejects empty / non-string values', () => {
+    expect(() => deriveFirestoreDocumentId('')).toThrow(
+      FirestoreInvalidDocumentIdException,
+    );
+    expect(() => deriveFirestoreDocumentId('   ')).toThrow(
+      FirestoreInvalidDocumentIdException,
+    );
+    expect(() => deriveFirestoreDocumentId(42)).toThrow(
+      FirestoreInvalidDocumentIdException,
+    );
+  });
+
+  it('hashes ids that contain /', () => {
+    const id = deriveFirestoreDocumentId('a/b');
+    expect(id).toMatch(/^u_[a-f0-9]{64}$/);
+    expect(id).not.toContain('/');
+  });
+
+  it('hashes "." and ".."', () => {
+    expect(deriveFirestoreDocumentId('.')).toMatch(/^u_[a-f0-9]{64}$/);
+    expect(deriveFirestoreDocumentId('..')).toMatch(/^u_[a-f0-9]{64}$/);
+  });
+
+  it('hashes reserved __*__ names', () => {
+    expect(deriveFirestoreDocumentId('__name__')).toMatch(/^u_[a-f0-9]{64}$/);
+  });
+
+  it('hashes values longer than 1500 UTF-8 bytes', () => {
+    // "é" is 2 bytes in UTF-8; 800 chars → 1600 bytes.
+    const oversized = 'é'.repeat(800);
+    expect(Buffer.byteLength(oversized, 'utf8')).toBeGreaterThan(1500);
+    expect(deriveFirestoreDocumentId(oversized)).toMatch(/^u_[a-f0-9]{64}$/);
+  });
+});

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-increment.spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-increment.spec.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import { Test } from '@nestjs/testing';
+import {
+  getDynamicRepositoryToken,
+  Where,
+  type RepositoryInterface,
+} from '@concepta/nestjs-repository';
+
+import { InMemoryFirestoreBackend } from '../backends/in-memory-firestore.backend';
+import { FirestorePreconditionFailedException } from '../exceptions/firestore-precondition-failed.exception';
+import { FirestoreRepositoryModule } from '../firestore-repository.module';
+import { isFirestoreRepository } from '../repository/firestore-repository';
+
+class CounterEntity {
+  id!: string;
+  name!: string;
+  count!: number;
+}
+
+describe('FirestoreRepository.increment', () => {
+  it('writes only the counter field (does not clobber concurrent siblings)', async () => {
+    const backend = new InMemoryFirestoreBackend();
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FirestoreRepositoryModule.forFeature(
+          [
+            {
+              key: 'counter',
+              entity: CounterEntity,
+              collection: 'counters-increment',
+            },
+          ],
+          { backend },
+        ),
+      ],
+    }).compile();
+
+    const repo = moduleRef.get<RepositoryInterface<CounterEntity>>(
+      getDynamicRepositoryToken('counter'),
+    );
+    expect(isFirestoreRepository(repo)).toBe(true);
+    if (!isFirestoreRepository(repo)) {
+      throw new Error('expected FirestoreRepository');
+    }
+
+    const created = await repo.create({
+      id: 'c1',
+      name: 'A',
+      count: 5,
+    });
+
+    await backend.set('counters-increment', 'c1', { name: 'B' }, true);
+
+    await repo.increment(created, 'count', 1);
+
+    const stored = await backend.get('counters-increment', 'c1');
+    expect(stored).toEqual({
+      id: 'c1',
+      name: 'B',
+      count: 6,
+    });
+  });
+
+  it('rejects a missing document when exists: true (default)', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FirestoreRepositoryModule.forFeature(
+          [
+            {
+              key: 'counter',
+              entity: CounterEntity,
+              collection: 'counters-missing',
+            },
+          ],
+          { backend: new InMemoryFirestoreBackend() },
+        ),
+      ],
+    }).compile();
+
+    const repo = moduleRef.get<RepositoryInterface<CounterEntity>>(
+      getDynamicRepositoryToken('counter'),
+    );
+    expect(isFirestoreRepository(repo)).toBe(true);
+    if (!isFirestoreRepository(repo)) {
+      throw new Error('expected FirestoreRepository');
+    }
+
+    await expect(
+      repo.increment({ id: 'missing', name: 'x', count: 0 }, 'count', 1),
+    ).rejects.toBeInstanceOf(FirestorePreconditionFailedException);
+  });
+
+  it('updateWithPrecondition writes the patch when the document exists', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FirestoreRepositoryModule.forFeature(
+          [
+            {
+              key: 'counter',
+              entity: CounterEntity,
+              collection: 'counters-cas-ok',
+            },
+          ],
+          { backend: new InMemoryFirestoreBackend() },
+        ),
+      ],
+    }).compile();
+
+    const repo = moduleRef.get<RepositoryInterface<CounterEntity>>(
+      getDynamicRepositoryToken('counter'),
+    );
+    expect(isFirestoreRepository(repo)).toBe(true);
+    if (!isFirestoreRepository(repo)) {
+      throw new Error('expected FirestoreRepository');
+    }
+
+    const created = await repo.create({ id: 'c1', name: 'A', count: 1 });
+    await repo.updateWithPrecondition(
+      created,
+      { name: 'B' },
+      { precondition: { exists: true } },
+    );
+
+    await expect(
+      repo.findOne({ where: Where.eq('id', 'c1') }),
+    ).resolves.toMatchObject({ name: 'B', count: 1 });
+  });
+
+  it('updateWithPrecondition fails when exists: true and the document is missing', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FirestoreRepositoryModule.forFeature(
+          [
+            {
+              key: 'counter',
+              entity: CounterEntity,
+              collection: 'counters-cas',
+            },
+          ],
+          { backend: new InMemoryFirestoreBackend() },
+        ),
+      ],
+    }).compile();
+
+    const repo = moduleRef.get<RepositoryInterface<CounterEntity>>(
+      getDynamicRepositoryToken('counter'),
+    );
+    expect(isFirestoreRepository(repo)).toBe(true);
+    if (!isFirestoreRepository(repo)) {
+      throw new Error('expected FirestoreRepository');
+    }
+
+    await expect(
+      repo.updateWithPrecondition(
+        { id: 'missing', name: 'x', count: 0 },
+        { name: 'y' },
+        { precondition: { exists: true } },
+      ),
+    ).rejects.toBeInstanceOf(FirestorePreconditionFailedException);
+  });
+});

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-order-by-reconcile.spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-order-by-reconcile.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { reconcileOrderByWithInequality } from '../repository/firestore-order-by-reconcile';
+
+describe('reconcileOrderByWithInequality', () => {
+  it('prepends the inequality field when orderBy starts elsewhere', () => {
+    const result = reconcileOrderByWithInequality(
+      {
+        filters: [{ field: 'expiresAt', op: '<', value: new Date() }],
+        postFilters: [],
+      },
+      [{ field: 'name', direction: 'asc' }],
+    );
+
+    expect(result.serverOrderBy).toEqual([
+      { field: 'expiresAt', direction: 'asc' },
+      { field: 'name', direction: 'asc' },
+    ]);
+    expect(result.clientReorder).toBe(true);
+  });
+
+  it('leaves orderBy alone when the inequality field is already first', () => {
+    const result = reconcileOrderByWithInequality(
+      {
+        filters: [{ field: 'expiresAt', op: '>', value: new Date() }],
+        postFilters: [],
+      },
+      [
+        { field: 'expiresAt', direction: 'desc' },
+        { field: 'name', direction: 'asc' },
+      ],
+    );
+
+    expect(result.clientReorder).toBe(false);
+    expect(result.serverOrderBy?.[0]?.field).toBe('expiresAt');
+  });
+
+  it('injects inequality orderBy when the caller omitted order', () => {
+    const result = reconcileOrderByWithInequality(
+      {
+        filters: [{ field: 'score', op: '!=', value: null }],
+        postFilters: [],
+      },
+      undefined,
+    );
+
+    expect(result.serverOrderBy).toEqual([
+      { field: 'score', direction: 'asc' },
+    ]);
+    expect(result.clientReorder).toBe(false);
+  });
+});

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-order-by-reconcile.spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-order-by-reconcile.spec.ts
@@ -49,4 +49,48 @@ describe('reconcileOrderByWithInequality', () => {
     ]);
     expect(result.clientReorder).toBe(false);
   });
+
+  it('promotes every inequality field ahead of the requested orderBy', () => {
+    const result = reconcileOrderByWithInequality(
+      {
+        filters: [
+          { field: 'age', op: '>', value: 18 },
+          { field: 'score', op: '<', value: 100 },
+        ],
+        postFilters: [],
+      },
+      [{ field: 'name', direction: 'asc' }],
+    );
+
+    expect(result.serverOrderBy?.map((clause) => clause.field)).toEqual([
+      'age',
+      'score',
+      'name',
+    ]);
+    expect(result.clientReorder).toBe(true);
+  });
+
+  it('keeps pushdown when inequality fields lead in any order', () => {
+    const result = reconcileOrderByWithInequality(
+      {
+        filters: [
+          { field: 'age', op: '>', value: 18 },
+          { field: 'score', op: '<', value: 100 },
+        ],
+        postFilters: [],
+      },
+      [
+        { field: 'score', direction: 'desc' },
+        { field: 'age', direction: 'asc' },
+        { field: 'name', direction: 'asc' },
+      ],
+    );
+
+    expect(result.clientReorder).toBe(false);
+    expect(result.serverOrderBy?.map((clause) => clause.field)).toEqual([
+      'score',
+      'age',
+      'name',
+    ]);
+  });
 });

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-precondition.util.spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-precondition.util.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { Timestamp } from 'firebase-admin/firestore';
+
+import { FirestoreInvalidPreconditionException } from '../exceptions/firestore-invalid-precondition.exception';
+import { toAdminPrecondition } from '../utils/firestore-precondition.util';
+
+describe('toAdminPrecondition', () => {
+  it('returns undefined when no precondition is provided', () => {
+    expect(toAdminPrecondition(undefined)).toBeUndefined();
+  });
+
+  it('maps exists: true', () => {
+    expect(toAdminPrecondition({ exists: true })).toEqual({ exists: true });
+  });
+
+  it('maps lastUpdateTime to a Timestamp', () => {
+    const when = new Date('2024-01-02T03:04:05.000Z');
+    const result = toAdminPrecondition({ lastUpdateTime: when });
+    expect(result?.lastUpdateTime).toBeInstanceOf(Timestamp);
+    expect(result?.lastUpdateTime?.toDate()).toEqual(when);
+  });
+
+  it('rejects exists and lastUpdateTime together', () => {
+    expect(() =>
+      toAdminPrecondition({
+        exists: true,
+        lastUpdateTime: new Date(),
+      }),
+    ).toThrow(FirestoreInvalidPreconditionException);
+  });
+
+  it('rejects exists: false on set/update', () => {
+    expect(() => toAdminPrecondition({ exists: false }, 'set')).toThrow(
+      FirestoreInvalidPreconditionException,
+    );
+  });
+
+  it('allows exists: false on delete', () => {
+    expect(toAdminPrecondition({ exists: false }, 'delete')).toEqual({
+      exists: false,
+    });
+  });
+});

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-repository.module.spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-repository.module.spec.ts
@@ -683,6 +683,101 @@ describe(FirestoreRepositoryModule.name, () => {
     ]);
   });
 
+  it('keeps an upserted new document visible in default lists', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FirestoreRepositoryModule.forFeature(
+          [
+            {
+              key: 'soft-widget',
+              entity: SoftWidgetEntity,
+              collection: 'soft-widgets-upsert-visible',
+              softDeleteField: 'dateRemoved',
+            },
+          ],
+          { backend: new InMemoryFirestoreBackend() },
+        ),
+      ],
+    }).compile();
+
+    const repo = moduleRef.get<RepositoryInterface<SoftWidgetEntity>>(
+      getDynamicRepositoryToken('soft-widget'),
+    );
+
+    const created = await repo.upsert({ id: 'fresh', title: 'Fresh' });
+    expect(created).toMatchObject({ id: 'fresh', dateRemoved: null });
+
+    await expect(repo.find()).resolves.toEqual([
+      expect.objectContaining({ id: 'fresh' }),
+    ]);
+    await expect(repo.count()).resolves.toBe(1);
+  });
+
+  it('keeps a live document visible when replace omits the soft-delete field', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FirestoreRepositoryModule.forFeature(
+          [
+            {
+              key: 'soft-widget',
+              entity: SoftWidgetEntity,
+              collection: 'soft-widgets-replace-visible',
+              softDeleteField: 'dateRemoved',
+            },
+          ],
+          { backend: new InMemoryFirestoreBackend() },
+        ),
+      ],
+    }).compile();
+
+    const repo = moduleRef.get<RepositoryInterface<SoftWidgetEntity>>(
+      getDynamicRepositoryToken('soft-widget'),
+    );
+
+    await repo.create({ id: 'live', title: 'Live' });
+    const live = await repo.findOne({ where: Where.eq('id', 'live') });
+
+    await repo.replace(live!, { id: 'live', title: 'Replaced' });
+
+    await expect(repo.find()).resolves.toEqual([
+      expect.objectContaining({ id: 'live', title: 'Replaced' }),
+    ]);
+    await expect(repo.count()).resolves.toBe(1);
+  });
+
+  it('keeps a soft-deleted document deleted when replace omits the field', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FirestoreRepositoryModule.forFeature(
+          [
+            {
+              key: 'soft-widget',
+              entity: SoftWidgetEntity,
+              collection: 'soft-widgets-replace-deleted',
+              softDeleteField: 'dateRemoved',
+            },
+          ],
+          { backend: new InMemoryFirestoreBackend() },
+        ),
+      ],
+    }).compile();
+
+    const repo = moduleRef.get<RepositoryInterface<SoftWidgetEntity>>(
+      getDynamicRepositoryToken('soft-widget'),
+    );
+
+    await repo.create({ id: 'gone', title: 'Gone' });
+    const created = await repo.findOne({ where: Where.eq('id', 'gone') });
+    const removed = await repo.softDelete(created!);
+
+    await repo.replace(removed, { id: 'gone', title: 'Replaced' });
+
+    await expect(repo.find()).resolves.toEqual([]);
+    await expect(repo.find({ withDeleted: true })).resolves.toEqual([
+      expect.objectContaining({ id: 'gone', title: 'Replaced' }),
+    ]);
+  });
+
   it('backfillSoftDeleteNull restores legacy docs missing the soft-delete field', async () => {
     const backend = new InMemoryFirestoreBackend();
     await backend.set('soft-widgets-backfill', 'legacy', {

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-repository.module.spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-repository.module.spec.ts
@@ -896,4 +896,93 @@ describe(FirestoreRepositoryModule.name, () => {
       expect.objectContaining({ id: 'legacy' }),
     ]);
   });
+
+  it('derives the document id from uniqueDocumentIdField', async () => {
+    class BucketEntity {
+      id!: string;
+      bucketKey!: string;
+      title!: string;
+    }
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FirestoreRepositoryModule.forFeature(
+          [
+            {
+              key: 'bucket',
+              entity: BucketEntity,
+              collection: 'buckets-unique',
+              uniqueDocumentIdField: 'bucketKey',
+            },
+          ],
+          { backend: new InMemoryFirestoreBackend() },
+        ),
+      ],
+    }).compile();
+
+    const repo = moduleRef.get<RepositoryInterface<BucketEntity>>(
+      getDynamicRepositoryToken('bucket'),
+    );
+
+    const created = await repo.create({
+      bucketKey: 'tenant-a-orders',
+      title: 'Orders',
+    });
+    expect(created.id).toBe('tenant-a-orders');
+    await expect(
+      repo.findOne({ where: Where.eq('id', 'tenant-a-orders') }),
+    ).resolves.toMatchObject({ title: 'Orders' });
+  });
+
+  it('refuses composite uniqueConstraints at boot', () => {
+    expect(() =>
+      FirestoreRepositoryModule.forFeature(
+        [
+          {
+            key: 'widget',
+            entity: WidgetEntity,
+            uniqueConstraints: [['title', 'note']],
+          },
+        ],
+        { backend: new InMemoryFirestoreBackend() },
+      ),
+    ).toThrow(/composite unique constraint/);
+  });
+
+  it('createMany uses writeBatch outside a transaction', async () => {
+    const backend = new InMemoryFirestoreBackend();
+    const writeBatch = vi.spyOn(backend, 'writeBatch');
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FirestoreRepositoryModule.forFeature(
+          [
+            {
+              key: 'widget',
+              entity: WidgetEntity,
+              collection: 'widgets-batch-create',
+            },
+          ],
+          { backend },
+        ),
+      ],
+    }).compile();
+
+    const repo = moduleRef.get<RepositoryInterface<WidgetEntity>>(
+      getDynamicRepositoryToken('widget'),
+    );
+
+    const created = await repo.createMany([
+      { id: 'b1', title: 'One' },
+      { id: 'b2', title: 'Two' },
+    ]);
+    expect(created).toHaveLength(2);
+    expect(writeBatch).toHaveBeenCalled();
+    await expect(repo.find()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'b1' }),
+        expect.objectContaining({ id: 'b2' }),
+      ]),
+    );
+  });
 });

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-repository.module.spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-repository.module.spec.ts
@@ -778,6 +778,86 @@ describe(FirestoreRepositoryModule.name, () => {
     ]);
   });
 
+  it('does not resurrect when replace passes dateRemoved: undefined', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FirestoreRepositoryModule.forFeature(
+          [
+            {
+              key: 'soft-widget',
+              entity: SoftWidgetEntity,
+              collection: 'soft-widgets-replace-undefined',
+              softDeleteField: 'dateRemoved',
+            },
+          ],
+          { backend: new InMemoryFirestoreBackend() },
+        ),
+      ],
+    }).compile();
+
+    const repo = moduleRef.get<RepositoryInterface<SoftWidgetEntity>>(
+      getDynamicRepositoryToken('soft-widget'),
+    );
+
+    await repo.create({ id: 'gone', title: 'Gone' });
+    const created = await repo.findOne({ where: Where.eq('id', 'gone') });
+    const removed = await repo.softDelete(created!);
+
+    await repo.replace(removed, {
+      id: 'gone',
+      title: 'Replaced',
+      dateRemoved: undefined,
+    });
+
+    await expect(repo.find()).resolves.toEqual([]);
+    await expect(repo.find({ withDeleted: true })).resolves.toEqual([
+      expect.objectContaining({
+        id: 'gone',
+        dateRemoved: expect.any(Date),
+      }),
+    ]);
+  });
+
+  it('does not resurrect when replace uses a hand-built entity without dateRemoved', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FirestoreRepositoryModule.forFeature(
+          [
+            {
+              key: 'soft-widget',
+              entity: SoftWidgetEntity,
+              collection: 'soft-widgets-replace-handbuilt',
+              softDeleteField: 'dateRemoved',
+            },
+          ],
+          { backend: new InMemoryFirestoreBackend() },
+        ),
+      ],
+    }).compile();
+
+    const repo = moduleRef.get<RepositoryInterface<SoftWidgetEntity>>(
+      getDynamicRepositoryToken('soft-widget'),
+    );
+
+    await repo.create({ id: 'gone', title: 'Gone' });
+    const created = await repo.findOne({ where: Where.eq('id', 'gone') });
+    await repo.softDelete(created!);
+
+    await repo.replace({ id: 'gone' } as SoftWidgetEntity, {
+      id: 'gone',
+      title: 'Replaced',
+    });
+
+    await expect(repo.find()).resolves.toEqual([]);
+    await expect(repo.find({ withDeleted: true })).resolves.toEqual([
+      expect.objectContaining({
+        id: 'gone',
+        title: 'Replaced',
+        dateRemoved: expect.any(Date),
+      }),
+    ]);
+  });
+
   it('backfillSoftDeleteNull restores legacy docs missing the soft-delete field', async () => {
     const backend = new InMemoryFirestoreBackend();
     await backend.set('soft-widgets-backfill', 'legacy', {

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-repository.module.spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-repository.module.spec.ts
@@ -56,7 +56,7 @@ describe(FirestoreRepositoryModule.name, () => {
     ).toThrow(/initialize Firebase Admin/);
   });
 
-  it('registers a global dynamic module', () => {
+  it('registers a global dynamic module with a transaction factory', () => {
     const dynModule = FirestoreRepositoryModule.forFeature(
       [{ key: 'widget', entity: WidgetEntity }],
       { backend },
@@ -65,6 +65,7 @@ describe(FirestoreRepositoryModule.name, () => {
     expect(dynModule.module).toBe(FirestoreRepositoryModule);
     expect(dynModule.providers).toHaveLength(1);
     expect(dynModule.exports).toHaveLength(1);
+    expect(dynModule.transactionFactories).toHaveLength(1);
   });
 
   it('persists and reads through an explicit in-memory backend', async () => {

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-repository.module.spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-repository.module.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Test } from '@nestjs/testing';
 import {
   SortOrder,
@@ -8,8 +8,10 @@ import {
 import type { RepositoryInterface } from '@concepta/nestjs-repository';
 
 import { InMemoryFirestoreBackend } from '../backends/in-memory-firestore.backend';
+import { FIRESTORE_BACKEND } from '../constants/firestore-repository.constants';
 import { FirestoreDuplicateIdException } from '../exceptions/firestore-duplicate-id.exception';
 import { FirestoreRepositoryModule } from '../firestore-repository.module';
+import { backfillSoftDeleteNull } from '../utils/backfill-soft-delete-null';
 
 class WidgetEntity {
   id!: string;
@@ -63,9 +65,23 @@ describe(FirestoreRepositoryModule.name, () => {
     );
 
     expect(dynModule.module).toBe(FirestoreRepositoryModule);
-    expect(dynModule.providers).toHaveLength(1);
-    expect(dynModule.exports).toHaveLength(1);
+    expect(dynModule.providers).toHaveLength(2);
+    expect(dynModule.exports).toHaveLength(2);
     expect(dynModule.transactionFactories).toHaveLength(1);
+  });
+
+  it('exposes the shared backend through FIRESTORE_BACKEND', async () => {
+    const shared = new InMemoryFirestoreBackend();
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FirestoreRepositoryModule.forFeature(
+          [{ key: 'widget', entity: WidgetEntity, collection: 'widgets-di' }],
+          { backend: shared },
+        ),
+      ],
+    }).compile();
+
+    expect(moduleRef.get(FIRESTORE_BACKEND)).toBe(shared);
   });
 
   it('persists and reads through an explicit in-memory backend', async () => {
@@ -556,7 +572,7 @@ describe(FirestoreRepositoryModule.name, () => {
     expect(rows.map((row) => row.id)).toEqual(['present']);
   });
 
-  it('treats a missing soft-delete field as live by default', async () => {
+  it('materializes dateRemoved null on create so soft-delete lists stay server-pushable', async () => {
     const moduleRef = await Test.createTestingModule({
       imports: [
         FirestoreRepositoryModule.forFeature(
@@ -564,7 +580,7 @@ describe(FirestoreRepositoryModule.name, () => {
             {
               key: 'soft-widget',
               entity: SoftWidgetEntity,
-              collection: 'soft-widgets-missing-field',
+              collection: 'soft-widgets-materialize',
               softDeleteField: 'dateRemoved',
             },
           ],
@@ -579,8 +595,210 @@ describe(FirestoreRepositoryModule.name, () => {
 
     await repo.create({ id: 'live', title: 'Live' });
 
-    await expect(repo.find()).resolves.toEqual([
-      expect.objectContaining({ id: 'live' }),
+    const found = await repo.findOne({ where: Where.eq('id', 'live') });
+    expect(found).toMatchObject({ id: 'live', dateRemoved: null });
+  });
+
+  it('does not resurrect a soft-deleted row when update omits dateRemoved', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FirestoreRepositoryModule.forFeature(
+          [
+            {
+              key: 'soft-widget',
+              entity: SoftWidgetEntity,
+              collection: 'soft-widgets-no-resurrect',
+              softDeleteField: 'dateRemoved',
+            },
+          ],
+          { backend: new InMemoryFirestoreBackend() },
+        ),
+      ],
+    }).compile();
+
+    const repo = moduleRef.get<RepositoryInterface<SoftWidgetEntity>>(
+      getDynamicRepositoryToken('soft-widget'),
+    );
+
+    await repo.create({ id: 'gone', title: 'Gone' });
+    const created = await repo.findOne({ where: Where.eq('id', 'gone') });
+    await repo.softDelete(created!);
+
+    await repo.update({ id: 'gone', title: 'patched' } as SoftWidgetEntity, {
+      title: 'patched',
+    });
+
+    await expect(repo.find({ where: Where.eq('id', 'gone') })).resolves.toEqual(
+      [],
+    );
+    await expect(
+      repo.find({ where: Where.eq('id', 'gone'), withDeleted: true }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: 'gone',
+        title: 'patched',
+        dateRemoved: expect.any(Date),
+      }),
+    ]);
+  });
+
+  it('does not resurrect a soft-deleted row on upsert that omits dateRemoved', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FirestoreRepositoryModule.forFeature(
+          [
+            {
+              key: 'soft-widget',
+              entity: SoftWidgetEntity,
+              collection: 'soft-widgets-upsert-no-resurrect',
+              softDeleteField: 'dateRemoved',
+            },
+          ],
+          { backend: new InMemoryFirestoreBackend() },
+        ),
+      ],
+    }).compile();
+
+    const repo = moduleRef.get<RepositoryInterface<SoftWidgetEntity>>(
+      getDynamicRepositoryToken('soft-widget'),
+    );
+
+    await repo.create({ id: 'gone', title: 'Gone' });
+    const created = await repo.findOne({ where: Where.eq('id', 'gone') });
+    await repo.softDelete(created!);
+
+    await repo.upsert({ id: 'gone', title: 'upserted' });
+
+    await expect(repo.find({ where: Where.eq('id', 'gone') })).resolves.toEqual(
+      [],
+    );
+    await expect(
+      repo.find({ where: Where.eq('id', 'gone'), withDeleted: true }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: 'gone',
+        title: 'upserted',
+        dateRemoved: expect.any(Date),
+      }),
+    ]);
+  });
+
+  it('backfillSoftDeleteNull restores legacy docs missing the soft-delete field', async () => {
+    const backend = new InMemoryFirestoreBackend();
+    await backend.set('soft-widgets-backfill', 'legacy', {
+      id: 'legacy',
+      title: 'Legacy',
+    });
+    await backend.set('soft-widgets-backfill', 'already', {
+      id: 'already',
+      title: 'Already',
+      dateRemoved: null,
+    });
+
+    const patched = await backfillSoftDeleteNull({
+      backend,
+      collection: 'soft-widgets-backfill',
+      softDeleteField: 'dateRemoved',
+    });
+    expect(patched).toBe(1);
+    expect(await backend.get('soft-widgets-backfill', 'legacy')).toMatchObject({
+      dateRemoved: null,
+    });
+  });
+
+  it('pushes soft-delete exclusion as a server filter so take/count stay on the backend', async () => {
+    const backend = new InMemoryFirestoreBackend();
+    const queryBranch = vi.spyOn(backend, 'queryBranch');
+    const countBranch = vi.spyOn(backend, 'countBranch');
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FirestoreRepositoryModule.forFeature(
+          [
+            {
+              key: 'soft-widget',
+              entity: SoftWidgetEntity,
+              collection: 'soft-widgets-pushdown',
+              softDeleteField: 'dateRemoved',
+            },
+          ],
+          { backend },
+        ),
+      ],
+    }).compile();
+
+    const repo = moduleRef.get<RepositoryInterface<SoftWidgetEntity>>(
+      getDynamicRepositoryToken('soft-widget'),
+    );
+
+    await repo.create({ id: 'a', title: 'A' });
+    await repo.create({ id: 'b', title: 'B' });
+    await repo.create({ id: 'c', title: 'C' });
+    const doomed = await repo.findOne({ where: Where.eq('id', 'c') });
+    await repo.softDelete(doomed!);
+
+    queryBranch.mockClear();
+    countBranch.mockClear();
+
+    const page = await repo.find({
+      order: [{ field: 'title', order: SortOrder.ASC }],
+      take: 1,
+    });
+    expect(page).toHaveLength(1);
+    expect(page[0]?.id).toBe('a');
+
+    expect(queryBranch).toHaveBeenCalled();
+    const queryCall = queryBranch.mock.calls[0]?.[1];
+    expect(queryCall?.take).toBe(1);
+    expect(queryCall?.branch.postFilters).toEqual([]);
+    expect(queryCall?.branch.filters).toContainEqual({
+      field: 'dateRemoved',
+      op: '==',
+      value: null,
+    });
+
+    const total = await repo.count();
+    expect(total).toBe(2);
+    expect(countBranch).toHaveBeenCalled();
+    const countCall = countBranch.mock.calls[0]?.[1];
+    expect(countCall?.postFilters).toEqual([]);
+    expect(countCall?.filters).toContainEqual({
+      field: 'dateRemoved',
+      op: '==',
+      value: null,
+    });
+  });
+
+  it('excludes legacy soft-delete docs that omit the field (no materialize)', async () => {
+    const backend = new InMemoryFirestoreBackend();
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FirestoreRepositoryModule.forFeature(
+          [
+            {
+              key: 'soft-widget',
+              entity: SoftWidgetEntity,
+              collection: 'soft-widgets-missing-field',
+              softDeleteField: 'dateRemoved',
+            },
+          ],
+          { backend },
+        ),
+      ],
+    }).compile();
+
+    const repo = moduleRef.get<RepositoryInterface<SoftWidgetEntity>>(
+      getDynamicRepositoryToken('soft-widget'),
+    );
+
+    await backend.set('soft-widgets-missing-field', 'legacy', {
+      id: 'legacy',
+      title: 'Legacy',
+    });
+
+    await expect(repo.find()).resolves.toEqual([]);
+    await expect(repo.find({ withDeleted: true })).resolves.toEqual([
+      expect.objectContaining({ id: 'legacy' }),
     ]);
   });
 });

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-transaction.spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-transaction.spec.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Test } from '@nestjs/testing';
+import {
+  getDynamicRepositoryToken,
+  RepositoryModule,
+  TransactionScope,
+  Where,
+  type RepositoryInterface,
+  type RepositoryModuleInterface,
+  type RepositoryProviderOptions,
+} from '@concepta/nestjs-repository';
+
+import { InMemoryFirestoreBackend } from '../backends/in-memory-firestore.backend';
+import { FirestoreRepositoryModule } from '../firestore-repository.module';
+import { FirestoreTransaction } from '../transaction/firestore-transaction';
+import { FirestoreTransactionRetryUnsupportedException } from '../exceptions/firestore-transaction-retry-unsupported.exception';
+import { runInFirestoreTransaction } from '../transaction/run-in-firestore-transaction';
+import type { FirestoreBackend } from '../interfaces/firestore-backend.interface';
+import type { FirestoreTransactionHandle } from '../interfaces/firestore-transaction-handle.interface';
+import { FirestoreDuplicateIdException } from '../exceptions/firestore-duplicate-id.exception';
+
+class AccountEntity {
+  id!: string;
+  balance!: number;
+}
+
+function firestoreModuleFor(
+  backend: InMemoryFirestoreBackend,
+  collection: string,
+): RepositoryModuleInterface {
+  return {
+    name: FirestoreRepositoryModule.name,
+    forFeature: (entities: RepositoryProviderOptions[]) =>
+      FirestoreRepositoryModule.forFeature(
+        entities.map((entity) => ({
+          key: entity.key,
+          entity: entity.entity,
+          collection,
+        })),
+        { backend },
+      ),
+  };
+}
+
+describe('Firestore transactions (P1-1)', () => {
+  let backend: InMemoryFirestoreBackend;
+
+  beforeEach(() => {
+    backend = new InMemoryFirestoreBackend();
+  });
+
+  it('registers a transaction factory on forFeature', () => {
+    const feature = FirestoreRepositoryModule.forFeature(
+      [{ key: 'account', entity: AccountEntity, collection: 'accounts-tx' }],
+      { backend },
+    );
+
+    expect(feature.transactionFactories).toHaveLength(1);
+    expect(feature.transactionFactories?.[0]?.key).toMatch(/^firestore:/);
+  });
+
+  it('runTransaction commits multi-doc writes atomically', async () => {
+    await backend.create('accounts-cb', 'a', { id: 'a', balance: 100 });
+    await backend.create('accounts-cb', 'b', { id: 'b', balance: 0 });
+
+    await backend.runTransaction(async (tx) => {
+      const a = await tx.get('accounts-cb', 'a');
+      const b = await tx.get('accounts-cb', 'b');
+      expect(a).not.toBeNull();
+      expect(b).not.toBeNull();
+      await tx.set('accounts-cb', 'a', { id: 'a', balance: 75 }, false);
+      await tx.set('accounts-cb', 'b', { id: 'b', balance: 25 }, false);
+    });
+
+    expect(await backend.get('accounts-cb', 'a')).toMatchObject({
+      balance: 75,
+    });
+    expect(await backend.get('accounts-cb', 'b')).toMatchObject({
+      balance: 25,
+    });
+  });
+
+  it('runTransaction discards writes when the callback throws', async () => {
+    await backend.create('accounts-rb', 'a', { id: 'a', balance: 100 });
+
+    await expect(
+      backend.runTransaction(async (tx) => {
+        await tx.set('accounts-rb', 'a', { id: 'a', balance: 0 }, false);
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(await backend.get('accounts-rb', 'a')).toMatchObject({
+      balance: 100,
+    });
+  });
+
+  it('runTransaction rejects read-after-write', async () => {
+    await backend.create('accounts-raw', 'a', { id: 'a', balance: 100 });
+
+    await expect(
+      backend.runTransaction(async (tx) => {
+        await tx.set('accounts-raw', 'a', { id: 'a', balance: 50 }, false);
+        await tx.get('accounts-raw', 'a');
+      }),
+    ).rejects.toThrow(/all reads before all writes/);
+  });
+
+  it('imperative bridge refuses a Firestore retry instead of empty commit', async () => {
+    let attempts = 0;
+    const retryingBackend: FirestoreBackend = {
+      get: async () => null,
+      create: async () => undefined,
+      set: async () => undefined,
+      delete: async () => undefined,
+      queryBranch: async () => [],
+      countBranch: async () => 0,
+      runTransaction: async (fn) => {
+        const handle = {
+          get: async () => ({ id: 'a', balance: 100 }),
+          create: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+          queryBranch: async () => [],
+          countBranch: async () => 0,
+        } satisfies FirestoreTransactionHandle;
+        attempts += 1;
+        await fn(handle);
+        // Simulate SDK retry after the first successful callback return.
+        attempts += 1;
+        await fn(handle);
+        return undefined as never;
+      },
+    };
+
+    const tx = new FirestoreTransaction(retryingBackend);
+    await tx.start();
+    tx.markDirty();
+    await expect(tx.commit()).rejects.toBeInstanceOf(
+      FirestoreTransactionRetryUnsupportedException,
+    );
+    expect(attempts).toBe(2);
+  });
+
+  it('runInFirestoreTransaction joins ambient handle on repo calls', async () => {
+    const wired = await Test.createTestingModule({
+      imports: [
+        RepositoryModule.forRoot({}),
+        RepositoryModule.forFeature({
+          module: firestoreModuleFor(backend, 'accounts-callback'),
+          entities: [{ key: 'account', entity: AccountEntity }],
+        }),
+      ],
+    }).compile();
+
+    const repo = wired.get<RepositoryInterface<AccountEntity>>(
+      getDynamicRepositoryToken('account'),
+    );
+
+    await repo.create({ id: 'a', balance: 100 });
+    await repo.create({ id: 'b', balance: 0 });
+
+    await runInFirestoreTransaction(backend, async () => {
+      const a = await repo.findOne({ where: Where.eq('id', 'a') });
+      const b = await repo.findOne({ where: Where.eq('id', 'b') });
+      await repo.update(a!, { balance: 70 });
+      await repo.update(b!, { balance: 30 });
+    });
+
+    expect(await repo.findOne({ where: Where.eq('id', 'a') })).toMatchObject({
+      balance: 70,
+    });
+    expect(await repo.findOne({ where: Where.eq('id', 'b') })).toMatchObject({
+      balance: 30,
+    });
+  });
+
+  it('runInFirestoreTransaction re-executes the body when the SDK retries', async () => {
+    let bodyRuns = 0;
+    let attempts = 0;
+    const retryingBackend: FirestoreBackend = {
+      get: async () => null,
+      create: async () => undefined,
+      set: async () => undefined,
+      delete: async () => undefined,
+      queryBranch: async () => [],
+      countBranch: async () => 0,
+      runTransaction: async (fn) => {
+        const handle = {
+          get: async () => null,
+          create: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+          queryBranch: async () => [],
+          countBranch: async () => 0,
+        } satisfies FirestoreTransactionHandle;
+        attempts += 1;
+        await fn(handle);
+        if (attempts === 1) {
+          attempts += 1;
+          return fn(handle);
+        }
+        return undefined as never;
+      },
+    };
+
+    await runInFirestoreTransaction(retryingBackend, async () => {
+      bodyRuns += 1;
+    });
+
+    expect(attempts).toBe(2);
+    expect(bodyRuns).toBe(2);
+  });
+
+  it('runInFirestoreTransaction surfaces duplicate create as FirestoreDuplicateIdException', async () => {
+    await backend.create('dup-coll', 'same', { id: 'same', balance: 1 });
+
+    await expect(
+      backend.runTransaction(async (tx) => {
+        await tx.create('dup-coll', 'same', { id: 'same', balance: 2 });
+      }),
+    ).rejects.toBeInstanceOf(FirestoreDuplicateIdException);
+  });
+
+  it('TransactionScope + { ctx } joins ambient transaction on repo calls', async () => {
+    const wired = await Test.createTestingModule({
+      imports: [
+        RepositoryModule.forRoot({}),
+        RepositoryModule.forFeature({
+          module: firestoreModuleFor(backend, 'accounts-scope'),
+          entities: [{ key: 'account', entity: AccountEntity }],
+        }),
+      ],
+    }).compile();
+
+    const repo = wired.get<RepositoryInterface<AccountEntity>>(
+      getDynamicRepositoryToken('account'),
+    );
+    const scope = wired.get(TransactionScope);
+
+    await repo.create({ id: 'a', balance: 100 });
+    await repo.create({ id: 'b', balance: 0 });
+
+    await scope.run({}, async (ctx) => {
+      const a = await repo.findOne({ where: Where.eq('id', 'a'), ctx });
+      const b = await repo.findOne({ where: Where.eq('id', 'b'), ctx });
+      expect(a?.balance).toBe(100);
+      expect(b?.balance).toBe(0);
+      await repo.update(a!, { balance: 60 }, { ctx });
+      await repo.update(b!, { balance: 40 }, { ctx });
+    });
+
+    expect(await repo.findOne({ where: Where.eq('id', 'a') })).toMatchObject({
+      balance: 60,
+    });
+    expect(await repo.findOne({ where: Where.eq('id', 'b') })).toMatchObject({
+      balance: 40,
+    });
+  });
+
+  it('TransactionScope rolls back repo writes when the operation throws', async () => {
+    const wired = await Test.createTestingModule({
+      imports: [
+        RepositoryModule.forRoot({}),
+        RepositoryModule.forFeature({
+          module: firestoreModuleFor(backend, 'accounts-scope-rb'),
+          entities: [{ key: 'account', entity: AccountEntity }],
+        }),
+      ],
+    }).compile();
+
+    const repo = wired.get<RepositoryInterface<AccountEntity>>(
+      getDynamicRepositoryToken('account'),
+    );
+    const scope = wired.get(TransactionScope);
+
+    await repo.create({ id: 'a', balance: 100 });
+
+    await expect(
+      scope.run({}, async (ctx) => {
+        const a = await repo.findOne({ where: Where.eq('id', 'a'), ctx });
+        await repo.update(a!, { balance: 1 }, { ctx });
+        throw new Error('abort');
+      }),
+    ).rejects.toThrow('abort');
+
+    expect(await repo.findOne({ where: Where.eq('id', 'a') })).toMatchObject({
+      balance: 100,
+    });
+  });
+
+  it('propagation MANDATORY throws when no factory is registered', async () => {
+    const empty = await Test.createTestingModule({
+      imports: [RepositoryModule.forRoot({})],
+    }).compile();
+    const scope = empty.get(TransactionScope);
+
+    await expect(
+      scope.run({}, async () => 'ok', { propagation: 'MANDATORY' }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-transaction.spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-transaction.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Test } from '@nestjs/testing';
 import {
   getDynamicRepositoryToken,
@@ -389,6 +389,49 @@ describe('Firestore transactions (P1-1)', () => {
     ).resolves.toMatchObject({ balance: 1 });
   });
 
+  it('soft-deletable upsert on another backend during an ambient transaction writes independently, not a span error', async () => {
+    const other = new InMemoryFirestoreBackend();
+    const wired = await Test.createTestingModule({
+      imports: [
+        RepositoryModule.forRoot({}),
+        RepositoryModule.forFeature({
+          module: {
+            name: FirestoreRepositoryModule.name,
+            forFeature: (entities: RepositoryProviderOptions[]) =>
+              FirestoreRepositoryModule.forFeature(
+                entities.map((entity) => ({
+                  key: entity.key,
+                  entity: entity.entity,
+                  collection: 'soft-accounts-cross-backend',
+                  softDeleteField: 'dateRemoved',
+                })),
+                { backend: other },
+              ),
+          },
+          entities: [{ key: 'soft-account', entity: SoftAccountEntity }],
+        }),
+      ],
+    }).compile();
+
+    const repo = wired.get<RepositoryInterface<SoftAccountEntity>>(
+      getDynamicRepositoryToken('soft-account'),
+    );
+
+    // `backend` (A) owns the ambient transaction; `other` (B) is a different
+    // database. The soft-deletable upsert must NOT auto-open a B transaction
+    // (that would hit the cross-backend span guard and throw). It writes
+    // through B independently, still materializing the soft-delete marker.
+    await expect(
+      runInFirestoreTransaction(backend, async () => {
+        await repo.upsert({ id: 'a', balance: 1 });
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      repo.findOne({ where: Where.eq('id', 'a') }),
+    ).resolves.toMatchObject({ balance: 1, dateRemoved: null });
+  });
+
   it('transactional create after a write is rejected like the Admin handle', async () => {
     await expect(
       backend.runTransaction(async (tx) => {
@@ -572,6 +615,162 @@ describe('Firestore transactions (P1-1)', () => {
         await repo.upsert({ id: 'a', balance: 2 });
       }),
     ).rejects.toBeInstanceOf(FirestoreTransactionReadAfterWriteException);
+  });
+
+  it('soft-deletable upsert outside a transaction opens one so read+write are atomic', async () => {
+    const wired = await Test.createTestingModule({
+      imports: [
+        RepositoryModule.forRoot({}),
+        RepositoryModule.forFeature({
+          module: {
+            name: FirestoreRepositoryModule.name,
+            forFeature: (entities: RepositoryProviderOptions[]) =>
+              FirestoreRepositoryModule.forFeature(
+                entities.map((entity) => ({
+                  key: entity.key,
+                  entity: entity.entity,
+                  collection: 'soft-accounts-upsert-atomic',
+                  softDeleteField: 'dateRemoved',
+                })),
+                { backend },
+              ),
+          },
+          entities: [{ key: 'soft-account', entity: SoftAccountEntity }],
+        }),
+      ],
+    }).compile();
+
+    const repo = wired.get<RepositoryInterface<SoftAccountEntity>>(
+      getDynamicRepositoryToken('soft-account'),
+    );
+
+    const runTransaction = vi.spyOn(backend, 'runTransaction');
+    await repo.upsert({ id: 'a', balance: 1 });
+    expect(runTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('non-soft-deletable upsert skips the transaction (no read to race)', async () => {
+    const wired = await Test.createTestingModule({
+      imports: [
+        RepositoryModule.forRoot({}),
+        RepositoryModule.forFeature({
+          module: firestoreModuleFor(backend, 'accounts-upsert-plain'),
+          entities: [{ key: 'account', entity: AccountEntity }],
+        }),
+      ],
+    }).compile();
+
+    const repo = wired.get<RepositoryInterface<AccountEntity>>(
+      getDynamicRepositoryToken('account'),
+    );
+
+    const runTransaction = vi.spyOn(backend, 'runTransaction');
+    await repo.upsert({ id: 'a', balance: 1 });
+    expect(runTransaction).not.toHaveBeenCalled();
+  });
+
+  it('soft-deletable upsert detects a concurrent write and never resurrects a soft-deleted row', async () => {
+    // Instrumented backend: injects a concurrent create+soft-delete exactly
+    // once, during the upsert's in-transaction read and before it commits. The
+    // optimistic conflict check must then reject the attempt instead of writing
+    // a materialized `null` over the row soft-deleted underneath it.
+    class InterleavingBackend extends InMemoryFirestoreBackend {
+      private injected = false;
+      onFirstRead?: () => Promise<void>;
+
+      private async fireOnce(): Promise<void> {
+        if (this.injected || this.onFirstRead === undefined) {
+          return;
+        }
+        this.injected = true;
+        await this.onFirstRead();
+      }
+
+      override async runTransaction<T>(
+        fn: (tx: FirestoreTransactionHandle) => Promise<T>,
+      ): Promise<T> {
+        return super.runTransaction(async (tx) => {
+          const wrapped: FirestoreTransactionHandle = {
+            get: async (collection, id) => {
+              const row = await tx.get(collection, id);
+              await this.fireOnce();
+              return row;
+            },
+            create: tx.create.bind(tx),
+            set: tx.set.bind(tx),
+            delete: tx.delete.bind(tx),
+            queryBranch: tx.queryBranch.bind(tx),
+            countBranch: tx.countBranch.bind(tx),
+          };
+          return fn(wrapped);
+        });
+      }
+    }
+
+    const collection = 'soft-accounts-race';
+    const interleaving = new InterleavingBackend();
+    interleaving.onFirstRead = async () => {
+      await interleaving.create(collection, 'x', { id: 'x', balance: 9 });
+      await interleaving.set(
+        collection,
+        'x',
+        { dateRemoved: new Date() },
+        true,
+      );
+    };
+
+    const wired = await Test.createTestingModule({
+      imports: [
+        RepositoryModule.forRoot({}),
+        RepositoryModule.forFeature({
+          module: {
+            name: FirestoreRepositoryModule.name,
+            forFeature: (entities: RepositoryProviderOptions[]) =>
+              FirestoreRepositoryModule.forFeature(
+                entities.map((entity) => ({
+                  key: entity.key,
+                  entity: entity.entity,
+                  collection,
+                  softDeleteField: 'dateRemoved',
+                })),
+                { backend: interleaving },
+              ),
+          },
+          entities: [{ key: 'soft-account', entity: SoftAccountEntity }],
+        }),
+      ],
+    }).compile();
+
+    const repo = wired.get<RepositoryInterface<SoftAccountEntity>>(
+      getDynamicRepositoryToken('soft-account'),
+    );
+
+    // Read saw "missing", but the concurrent create+soft-delete lands before
+    // commit, so the attempt aborts on the optimistic-conflict check. The
+    // in-memory backend has no retry loop, so the abort surfaces as a throw;
+    // real Firestore RETRIES the aborted attempt and the re-read then sees the
+    // soft-deleted row (no resurrection) and resolves. Either way the
+    // resurrecting write never commits — the load-bearing proof is the
+    // visibility assertions below, not the throw shape.
+    //
+    // The repository permeator wraps the failure in a generic query exception,
+    // so assert on the preserved `originalError` to prove the abort came from
+    // the optimistic-conflict check and not some unrelated throw.
+    const rejection = await repo.upsert({ id: 'x', balance: 1 }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    const originalError = (
+      rejection as { context?: { originalError?: { message?: string } } }
+    ).context?.originalError;
+    expect(originalError?.message).toMatch(/in-memory transaction conflict/);
+
+    // The row stays soft-deleted: hidden from default reads, present with
+    // `withDeleted`, never resurrected by a stale `null`.
+    await expect(repo.find()).resolves.toEqual([]);
+    await expect(repo.find({ withDeleted: true })).resolves.toEqual([
+      expect.objectContaining({ id: 'x', dateRemoved: expect.any(Date) }),
+    ]);
   });
 
   it('createMany inside a transaction hoists existence reads before writes', async () => {

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-transaction.spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-transaction.spec.ts
@@ -20,7 +20,36 @@ import type { FirestoreBackend } from '../interfaces/firestore-backend.interface
 import type { FirestoreTransactionHandle } from '../interfaces/firestore-transaction-handle.interface';
 import { FirestoreDuplicateIdException } from '../exceptions/firestore-duplicate-id.exception';
 import { FirestoreTransactionBackendMismatchException } from '../exceptions/firestore-transaction-backend-mismatch.exception';
+import { FirestoreTransactionWriteLimitExceededException } from '../exceptions/firestore-transaction-write-limit-exceeded.exception';
 import { isFirestoreRepository } from '../repository/firestore-repository';
+import { FIRESTORE_MAX_TRANSACTION_WRITES } from '../constants/firestore-transaction.constants';
+import { firestoreIncrement } from '../interfaces/firestore-write.interface';
+
+function stubBackend(
+  overrides: Partial<FirestoreBackend> = {},
+): FirestoreBackend {
+  return {
+    get: async () => null,
+    create: async () => undefined,
+    set: async () => undefined,
+    delete: async () => undefined,
+    queryBranch: async () => [],
+    countBranch: async () => 0,
+    writeBatch: async () => undefined,
+    runTransaction: async (fn) => {
+      const handle = {
+        get: async () => null,
+        create: async () => undefined,
+        set: async () => undefined,
+        delete: async () => undefined,
+        queryBranch: async () => [],
+        countBranch: async () => 0,
+      } satisfies FirestoreTransactionHandle;
+      return fn(handle);
+    },
+    ...overrides,
+  };
+}
 
 class AccountEntity {
   id!: string;
@@ -111,13 +140,7 @@ describe('Firestore transactions (P1-1)', () => {
 
   it('imperative bridge refuses a Firestore retry instead of empty commit', async () => {
     let attempts = 0;
-    const retryingBackend: FirestoreBackend = {
-      get: async () => null,
-      create: async () => undefined,
-      set: async () => undefined,
-      delete: async () => undefined,
-      queryBranch: async () => [],
-      countBranch: async () => 0,
+    const retryingBackend = stubBackend({
       runTransaction: async (fn) => {
         const handle = {
           get: async () => ({ id: 'a', balance: 100 }),
@@ -129,12 +152,11 @@ describe('Firestore transactions (P1-1)', () => {
         } satisfies FirestoreTransactionHandle;
         attempts += 1;
         await fn(handle);
-        // Simulate SDK retry after the first successful callback return.
         attempts += 1;
         await fn(handle);
         return undefined as never;
       },
-    };
+    });
 
     const tx = new FirestoreTransaction(retryingBackend);
     await tx.start();
@@ -220,13 +242,7 @@ describe('Firestore transactions (P1-1)', () => {
   it('runInFirestoreTransaction re-executes the body when the SDK retries', async () => {
     let bodyRuns = 0;
     let attempts = 0;
-    const retryingBackend: FirestoreBackend = {
-      get: async () => null,
-      create: async () => undefined,
-      set: async () => undefined,
-      delete: async () => undefined,
-      queryBranch: async () => [],
-      countBranch: async () => 0,
+    const retryingBackend = stubBackend({
       runTransaction: async (fn) => {
         const handle = {
           get: async () => null,
@@ -244,7 +260,7 @@ describe('Firestore transactions (P1-1)', () => {
         }
         return undefined as never;
       },
-    };
+    });
 
     await runInFirestoreTransaction(retryingBackend, async () => {
       bodyRuns += 1;
@@ -256,13 +272,7 @@ describe('Firestore transactions (P1-1)', () => {
 
   it('nested runInFirestoreTransaction joins the ambient transaction', async () => {
     let outerStarts = 0;
-    const countingBackend: FirestoreBackend = {
-      get: async () => null,
-      create: async () => undefined,
-      set: async () => undefined,
-      delete: async () => undefined,
-      queryBranch: async () => [],
-      countBranch: async () => 0,
+    const countingBackend = stubBackend({
       runTransaction: async (fn) => {
         outerStarts += 1;
         const handle = {
@@ -275,7 +285,7 @@ describe('Firestore transactions (P1-1)', () => {
         } satisfies FirestoreTransactionHandle;
         return fn(handle);
       },
-    };
+    });
 
     const result = await runInFirestoreTransaction(
       countingBackend,
@@ -289,6 +299,48 @@ describe('Firestore transactions (P1-1)', () => {
 
     expect(result).toBe('nested-ok');
     expect(outerStarts).toBe(1);
+  });
+
+  it('refuses more than 500 writes in one transaction', async () => {
+    await expect(
+      backend.runTransaction(async (tx) => {
+        for (let i = 0; i <= FIRESTORE_MAX_TRANSACTION_WRITES; i += 1) {
+          await tx.set(
+            'accounts-limit',
+            `row-${i}`,
+            { id: `row-${i}`, balance: i },
+            false,
+          );
+        }
+      }),
+    ).rejects.toBeInstanceOf(FirestoreTransactionWriteLimitExceededException);
+  });
+
+  it('applies firestoreIncrement without a transaction', async () => {
+    await backend.create('counters', 'c1', { id: 'c1', value: 1 });
+    await backend.set('counters', 'c1', { value: firestoreIncrement(4) }, true);
+    expect(await backend.get('counters', 'c1')).toMatchObject({ value: 5 });
+  });
+
+  it('writeBatch creates atomically and rolls back on duplicate', async () => {
+    await backend.create('batch-coll', 'a', { id: 'a', balance: 1 });
+    await expect(
+      backend.writeBatch([
+        {
+          op: 'create',
+          collection: 'batch-coll',
+          id: 'b',
+          data: { id: 'b', balance: 2 },
+        },
+        {
+          op: 'create',
+          collection: 'batch-coll',
+          id: 'a',
+          data: { id: 'a', balance: 3 },
+        },
+      ]),
+    ).rejects.toBeInstanceOf(FirestoreDuplicateIdException);
+    expect(await backend.get('batch-coll', 'b')).toBeNull();
   });
 
   it('nested runInFirestoreTransaction refuses a different backend', async () => {

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-transaction.spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-transaction.spec.ts
@@ -11,6 +11,7 @@ import {
 } from '@concepta/nestjs-repository';
 
 import { InMemoryFirestoreBackend } from '../backends/in-memory-firestore.backend';
+import { FIRESTORE_BACKEND } from '../constants/firestore-repository.constants';
 import { FirestoreRepositoryModule } from '../firestore-repository.module';
 import { FirestoreTransaction } from '../transaction/firestore-transaction';
 import { FirestoreTransactionRetryUnsupportedException } from '../exceptions/firestore-transaction-retry-unsupported.exception';
@@ -18,6 +19,7 @@ import { runInFirestoreTransaction } from '../transaction/run-in-firestore-trans
 import type { FirestoreBackend } from '../interfaces/firestore-backend.interface';
 import type { FirestoreTransactionHandle } from '../interfaces/firestore-transaction-handle.interface';
 import { FirestoreDuplicateIdException } from '../exceptions/firestore-duplicate-id.exception';
+import { isFirestoreRepository } from '../repository/firestore-repository';
 
 class AccountEntity {
   id!: string;
@@ -175,6 +177,45 @@ describe('Firestore transactions (P1-1)', () => {
     });
   });
 
+  it('FirestoreRepository.transaction joins ambient handle without passing backend', async () => {
+    const wired = await Test.createTestingModule({
+      imports: [
+        RepositoryModule.forRoot({}),
+        RepositoryModule.forFeature({
+          module: firestoreModuleFor(backend, 'accounts-repo-tx'),
+          entities: [{ key: 'account', entity: AccountEntity }],
+        }),
+      ],
+    }).compile();
+
+    const repo = wired.get<RepositoryInterface<AccountEntity>>(
+      getDynamicRepositoryToken('account'),
+    );
+    expect(isFirestoreRepository(repo)).toBe(true);
+    if (!isFirestoreRepository(repo)) {
+      throw new Error('expected FirestoreRepository');
+    }
+
+    expect(wired.get(FIRESTORE_BACKEND)).toBe(backend);
+
+    await repo.create({ id: 'a', balance: 100 });
+    await repo.create({ id: 'b', balance: 0 });
+
+    await repo.transaction(async () => {
+      const a = await repo.findOne({ where: Where.eq('id', 'a') });
+      const b = await repo.findOne({ where: Where.eq('id', 'b') });
+      await repo.update(a!, { balance: 55 });
+      await repo.update(b!, { balance: 45 });
+    });
+
+    expect(await repo.findOne({ where: Where.eq('id', 'a') })).toMatchObject({
+      balance: 55,
+    });
+    expect(await repo.findOne({ where: Where.eq('id', 'b') })).toMatchObject({
+      balance: 45,
+    });
+  });
+
   it('runInFirestoreTransaction re-executes the body when the SDK retries', async () => {
     let bodyRuns = 0;
     let attempts = 0;
@@ -210,6 +251,43 @@ describe('Firestore transactions (P1-1)', () => {
 
     expect(attempts).toBe(2);
     expect(bodyRuns).toBe(2);
+  });
+
+  it('nested runInFirestoreTransaction joins the ambient transaction', async () => {
+    let outerStarts = 0;
+    const countingBackend: FirestoreBackend = {
+      get: async () => null,
+      create: async () => undefined,
+      set: async () => undefined,
+      delete: async () => undefined,
+      queryBranch: async () => [],
+      countBranch: async () => 0,
+      runTransaction: async (fn) => {
+        outerStarts += 1;
+        const handle = {
+          get: async () => null,
+          create: async () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined,
+          queryBranch: async () => [],
+          countBranch: async () => 0,
+        } satisfies FirestoreTransactionHandle;
+        return fn(handle);
+      },
+    };
+
+    const result = await runInFirestoreTransaction(
+      countingBackend,
+      async () => {
+        return runInFirestoreTransaction(
+          countingBackend,
+          async () => 'nested-ok',
+        );
+      },
+    );
+
+    expect(result).toBe('nested-ok');
+    expect(outerStarts).toBe(1);
   });
 
   it('runInFirestoreTransaction surfaces duplicate create as FirestoreDuplicateIdException', async () => {

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-transaction.spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-transaction.spec.ts
@@ -19,6 +19,7 @@ import { runInFirestoreTransaction } from '../transaction/run-in-firestore-trans
 import type { FirestoreBackend } from '../interfaces/firestore-backend.interface';
 import type { FirestoreTransactionHandle } from '../interfaces/firestore-transaction-handle.interface';
 import { FirestoreDuplicateIdException } from '../exceptions/firestore-duplicate-id.exception';
+import { FirestoreTransactionBackendMismatchException } from '../exceptions/firestore-transaction-backend-mismatch.exception';
 import { isFirestoreRepository } from '../repository/firestore-repository';
 
 class AccountEntity {
@@ -288,6 +289,59 @@ describe('Firestore transactions (P1-1)', () => {
 
     expect(result).toBe('nested-ok');
     expect(outerStarts).toBe(1);
+  });
+
+  it('nested runInFirestoreTransaction refuses a different backend', async () => {
+    const other = new InMemoryFirestoreBackend();
+
+    await expect(
+      runInFirestoreTransaction(backend, async () =>
+        runInFirestoreTransaction(other, async () => 'should not run'),
+      ),
+    ).rejects.toBeInstanceOf(FirestoreTransactionBackendMismatchException);
+  });
+
+  it('a repository on another backend does not join the ambient transaction', async () => {
+    const other = new InMemoryFirestoreBackend();
+    const wired = await Test.createTestingModule({
+      imports: [
+        RepositoryModule.forRoot({}),
+        RepositoryModule.forFeature({
+          module: firestoreModuleFor(other, 'accounts-other-backend'),
+          entities: [{ key: 'account', entity: AccountEntity }],
+        }),
+      ],
+    }).compile();
+
+    const repo = wired.get<RepositoryInterface<AccountEntity>>(
+      getDynamicRepositoryToken('account'),
+    );
+
+    await expect(
+      runInFirestoreTransaction(backend, async () => {
+        await repo.create({ id: 'a', balance: 1 });
+        throw new Error('roll back the ambient transaction');
+      }),
+    ).rejects.toThrow('roll back the ambient transaction');
+
+    // Written through its own backend, so the ambient rollback cannot undo it.
+    await expect(
+      repo.findOne({ where: Where.eq('id', 'a') }),
+    ).resolves.toMatchObject({ balance: 1 });
+  });
+
+  it('transactional create after a write is rejected like the Admin handle', async () => {
+    await expect(
+      backend.runTransaction(async (tx) => {
+        await tx.set(
+          'accounts-read-order',
+          'a',
+          { id: 'a', balance: 1 },
+          false,
+        );
+        await tx.create('accounts-read-order', 'b', { id: 'b', balance: 2 });
+      }),
+    ).rejects.toThrow(/all reads before all writes/);
   });
 
   it('runInFirestoreTransaction surfaces duplicate create as FirestoreDuplicateIdException', async () => {

--- a/packages/rockets-repository-firestore/src/__tests__/firestore-transaction.spec.ts
+++ b/packages/rockets-repository-firestore/src/__tests__/firestore-transaction.spec.ts
@@ -20,6 +20,7 @@ import type { FirestoreBackend } from '../interfaces/firestore-backend.interface
 import type { FirestoreTransactionHandle } from '../interfaces/firestore-transaction-handle.interface';
 import { FirestoreDuplicateIdException } from '../exceptions/firestore-duplicate-id.exception';
 import { FirestoreTransactionBackendMismatchException } from '../exceptions/firestore-transaction-backend-mismatch.exception';
+import { FirestoreTransactionReadAfterWriteException } from '../exceptions/firestore-transaction-read-after-write.exception';
 import { FirestoreTransactionWriteLimitExceededException } from '../exceptions/firestore-transaction-write-limit-exceeded.exception';
 import { isFirestoreRepository } from '../repository/firestore-repository';
 import { FIRESTORE_MAX_TRANSACTION_WRITES } from '../constants/firestore-transaction.constants';
@@ -54,6 +55,12 @@ function stubBackend(
 class AccountEntity {
   id!: string;
   balance!: number;
+}
+
+class SoftAccountEntity {
+  id!: string;
+  balance!: number;
+  dateRemoved!: Date | null;
 }
 
 function firestoreModuleFor(
@@ -135,7 +142,7 @@ describe('Firestore transactions (P1-1)', () => {
         await tx.set('accounts-raw', 'a', { id: 'a', balance: 50 }, false);
         await tx.get('accounts-raw', 'a');
       }),
-    ).rejects.toThrow(/all reads before all writes/);
+    ).rejects.toBeInstanceOf(FirestoreTransactionReadAfterWriteException);
   });
 
   it('imperative bridge refuses a Firestore retry instead of empty commit', async () => {
@@ -393,7 +400,7 @@ describe('Firestore transactions (P1-1)', () => {
         );
         await tx.create('accounts-read-order', 'b', { id: 'b', balance: 2 });
       }),
-    ).rejects.toThrow(/all reads before all writes/);
+    ).rejects.toBeInstanceOf(FirestoreTransactionReadAfterWriteException);
   });
 
   it('runInFirestoreTransaction surfaces duplicate create as FirestoreDuplicateIdException', async () => {
@@ -482,5 +489,159 @@ describe('Firestore transactions (P1-1)', () => {
     await expect(
       scope.run({}, async () => 'ok', { propagation: 'MANDATORY' }),
     ).rejects.toThrow();
+  });
+
+  it('soft-deletable upsert before a write succeeds inside a transaction', async () => {
+    const wired = await Test.createTestingModule({
+      imports: [
+        RepositoryModule.forRoot({}),
+        RepositoryModule.forFeature({
+          module: {
+            name: FirestoreRepositoryModule.name,
+            forFeature: (entities: RepositoryProviderOptions[]) =>
+              FirestoreRepositoryModule.forFeature(
+                entities.map((entity) => ({
+                  key: entity.key,
+                  entity: entity.entity,
+                  collection: 'soft-accounts-upsert-ok',
+                  softDeleteField: 'dateRemoved',
+                })),
+                { backend },
+              ),
+          },
+          entities: [{ key: 'soft-account', entity: SoftAccountEntity }],
+        }),
+      ],
+    }).compile();
+
+    const repo = wired.get<RepositoryInterface<SoftAccountEntity>>(
+      getDynamicRepositoryToken('soft-account'),
+    );
+    expect(isFirestoreRepository(repo)).toBe(true);
+    if (!isFirestoreRepository(repo)) {
+      throw new Error('expected FirestoreRepository');
+    }
+
+    await repo.transaction(async () => {
+      await repo.upsert({ id: 'a', balance: 1 });
+      await repo.update(
+        { id: 'a', balance: 1, dateRemoved: null },
+        { balance: 2 },
+      );
+    });
+
+    await expect(
+      repo.findOne({ where: Where.eq('id', 'a') }),
+    ).resolves.toMatchObject({ balance: 2, dateRemoved: null });
+  });
+
+  it('soft-deletable upsert after a write throws FIRESTORE_TRANSACTION_READ_AFTER_WRITE', async () => {
+    const wired = await Test.createTestingModule({
+      imports: [
+        RepositoryModule.forRoot({}),
+        RepositoryModule.forFeature({
+          module: {
+            name: FirestoreRepositoryModule.name,
+            forFeature: (entities: RepositoryProviderOptions[]) =>
+              FirestoreRepositoryModule.forFeature(
+                entities.map((entity) => ({
+                  key: entity.key,
+                  entity: entity.entity,
+                  collection: 'soft-accounts-upsert-raw',
+                  softDeleteField: 'dateRemoved',
+                })),
+                { backend },
+              ),
+          },
+          entities: [{ key: 'soft-account', entity: SoftAccountEntity }],
+        }),
+      ],
+    }).compile();
+
+    const repo = wired.get<RepositoryInterface<SoftAccountEntity>>(
+      getDynamicRepositoryToken('soft-account'),
+    );
+    expect(isFirestoreRepository(repo)).toBe(true);
+    if (!isFirestoreRepository(repo)) {
+      throw new Error('expected FirestoreRepository');
+    }
+
+    await expect(
+      repo.transaction(async () => {
+        await repo.create({ id: 'a', balance: 1 });
+        await repo.upsert({ id: 'a', balance: 2 });
+      }),
+    ).rejects.toBeInstanceOf(FirestoreTransactionReadAfterWriteException);
+  });
+
+  it('createMany inside a transaction hoists existence reads before writes', async () => {
+    const wired = await Test.createTestingModule({
+      imports: [
+        RepositoryModule.forRoot({}),
+        RepositoryModule.forFeature({
+          module: firestoreModuleFor(backend, 'accounts-create-many-tx'),
+          entities: [{ key: 'account', entity: AccountEntity }],
+        }),
+      ],
+    }).compile();
+
+    const repo = wired.get<RepositoryInterface<AccountEntity>>(
+      getDynamicRepositoryToken('account'),
+    );
+    expect(isFirestoreRepository(repo)).toBe(true);
+    if (!isFirestoreRepository(repo)) {
+      throw new Error('expected FirestoreRepository');
+    }
+
+    await repo.transaction(async () => {
+      await repo.createMany([
+        { id: 'a', balance: 1 },
+        { id: 'b', balance: 2 },
+        { id: 'c', balance: 3 },
+      ]);
+    });
+
+    await expect(repo.find()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'a', balance: 1 }),
+        expect.objectContaining({ id: 'b', balance: 2 }),
+        expect.objectContaining({ id: 'c', balance: 3 }),
+      ]),
+    );
+  });
+
+  it('createMany inside a transaction rejects a duplicate id before writing', async () => {
+    const wired = await Test.createTestingModule({
+      imports: [
+        RepositoryModule.forRoot({}),
+        RepositoryModule.forFeature({
+          module: firestoreModuleFor(backend, 'accounts-create-many-dup'),
+          entities: [{ key: 'account', entity: AccountEntity }],
+        }),
+      ],
+    }).compile();
+
+    const repo = wired.get<RepositoryInterface<AccountEntity>>(
+      getDynamicRepositoryToken('account'),
+    );
+    expect(isFirestoreRepository(repo)).toBe(true);
+    if (!isFirestoreRepository(repo)) {
+      throw new Error('expected FirestoreRepository');
+    }
+
+    await repo.create({ id: 'a', balance: 1 });
+
+    await expect(
+      repo.transaction(async () => {
+        await repo.createMany([
+          { id: 'b', balance: 2 },
+          { id: 'a', balance: 3 },
+        ]);
+      }),
+    ).rejects.toBeInstanceOf(FirestoreDuplicateIdException);
+
+    await expect(
+      repo.findOne({ where: Where.eq('id', 'b') }),
+    ).resolves.toBeNull();
   });
 });

--- a/packages/rockets-repository-firestore/src/backends/admin-firestore.backend.ts
+++ b/packages/rockets-repository-firestore/src/backends/admin-firestore.backend.ts
@@ -1,15 +1,21 @@
 import { getApp } from 'firebase-admin/app';
 import {
+  FieldValue,
   getFirestore,
+  Timestamp,
   type DocumentData,
   type Firestore,
+  type Precondition,
   type Query,
   type Transaction,
 } from 'firebase-admin/firestore';
 
+import { FIRESTORE_MAX_BATCH_WRITES } from '../constants/firestore-transaction.constants';
 import { FirestoreDuplicateIdException } from '../exceptions/firestore-duplicate-id.exception';
+import { FirestorePreconditionFailedException } from '../exceptions/firestore-precondition-failed.exception';
 import type {
   FirestoreBackend,
+  FirestoreBatchOperation,
   FirestoreBranchQueryOptions,
 } from '../interfaces/firestore-backend.interface';
 import type {
@@ -18,15 +24,19 @@ import type {
   FirestoreQueryBranch,
 } from '../interfaces/firestore-query.interface';
 import type { FirestoreTransactionHandle } from '../interfaces/firestore-transaction-handle.interface';
+import type { FirestoreWritePrecondition } from '../interfaces/firestore-write.interface';
+import { isFirestoreIncrementSentinel } from '../interfaces/firestore-write.interface';
 import { applyFirestorePostFilters } from '../repository/firestore-post-filter';
+import { reconcileOrderByWithInequality } from '../repository/firestore-order-by-reconcile';
 import { applyFirestoreFilters } from '../repository/firestore-row-filter';
 import { sortFirestoreRows } from '../repository/firestore-sort';
 import { normalizeFirestoreValue } from '../repository/firestore-value';
+import { FirestoreTransactionWriteCounter } from '../transaction/firestore-transaction-write-counter';
 
-// Batched reads keep argument lists bounded; getAll itself has no hard cap.
 const GET_ALL_CHUNK = 300;
 
 const GRPC_ALREADY_EXISTS = 6;
+const GRPC_FAILED_PRECONDITION = 9;
 
 function isAlreadyExistsError(error: unknown): boolean {
   return (
@@ -37,8 +47,42 @@ function isAlreadyExistsError(error: unknown): boolean {
   );
 }
 
+function isFailedPreconditionError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === GRPC_FAILED_PRECONDITION
+  );
+}
+
 function serialise(data: Record<string, unknown>): Record<string, unknown> {
-  return { ...data };
+  const next: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (isFirestoreIncrementSentinel(value)) {
+      next[key] = FieldValue.increment(value.__firestoreIncrement);
+    } else {
+      next[key] = value;
+    }
+  }
+  return next;
+}
+
+function toAdminPrecondition(
+  precondition: FirestoreWritePrecondition | undefined,
+): Precondition | undefined {
+  if (precondition === undefined) {
+    return undefined;
+  }
+  if (precondition.lastUpdateTime !== undefined) {
+    return {
+      lastUpdateTime: Timestamp.fromDate(precondition.lastUpdateTime),
+    };
+  }
+  if (precondition.exists !== undefined) {
+    return { exists: precondition.exists };
+  }
+  return undefined;
 }
 
 function normalise(
@@ -56,6 +100,8 @@ function normalise(
 }
 
 class AdminFirestoreTransactionHandle implements FirestoreTransactionHandle {
+  private readonly writes = new FirestoreTransactionWriteCounter();
+
   constructor(
     private readonly transaction: Transaction,
     private readonly db: Firestore,
@@ -79,16 +125,12 @@ class AdminFirestoreTransactionHandle implements FirestoreTransactionHandle {
     documentId: string,
     data: Record<string, unknown>,
   ): Promise<void> {
-    // ALREADY_EXISTS for transaction.create() surfaces at commit, not at
-    // enqueue — so read first and throw the adapter's 409 shape here. Under
-    // contention Firestore retries the whole attempt; the loser then sees
-    // the winner's doc and gets FirestoreDuplicateIdException instead of a
-    // raw gRPC error.
     const ref = this.db.collection(collection).doc(documentId);
     const snap = await this.transaction.get(ref);
     if (snap.exists) {
       throw new FirestoreDuplicateIdException(collection, documentId);
     }
+    this.writes.recordWrite();
     this.transaction.create(ref, serialise(data));
   }
 
@@ -97,16 +139,32 @@ class AdminFirestoreTransactionHandle implements FirestoreTransactionHandle {
     documentId: string,
     data: Record<string, unknown>,
     merge = false,
+    precondition?: FirestoreWritePrecondition,
   ): Promise<void> {
-    this.transaction.set(
-      this.db.collection(collection).doc(documentId),
-      serialise(data),
-      { merge },
-    );
+    this.writes.recordWrite();
+    const ref = this.db.collection(collection).doc(documentId);
+    const adminPrecondition = toAdminPrecondition(precondition);
+    // Precondition is only valid on update/delete in the Admin SDK.
+    if (adminPrecondition) {
+      this.transaction.update(ref, serialise(data), adminPrecondition);
+      return;
+    }
+    this.transaction.set(ref, serialise(data), { merge });
   }
 
-  async delete(collection: string, documentId: string): Promise<void> {
-    this.transaction.delete(this.db.collection(collection).doc(documentId));
+  async delete(
+    collection: string,
+    documentId: string,
+    precondition?: FirestoreWritePrecondition,
+  ): Promise<void> {
+    this.writes.recordWrite();
+    const ref = this.db.collection(collection).doc(documentId);
+    const adminPrecondition = toAdminPrecondition(precondition);
+    if (adminPrecondition) {
+      this.transaction.delete(ref, adminPrecondition);
+    } else {
+      this.transaction.delete(ref);
+    }
   }
 
   async queryBranch(
@@ -116,6 +174,9 @@ class AdminFirestoreTransactionHandle implements FirestoreTransactionHandle {
     const branch = options.branch;
     const skip = options.skip ?? 0;
     const take = options.take;
+    const reconciled = reconcileOrderByWithInequality(branch, options.orderBy);
+    const pushLimit =
+      branch.postFilters.length === 0 && !reconciled.clientReorder;
 
     if (branch.documentId !== undefined || branch.documentIds !== undefined) {
       const rows = await this.loadBranchRows(collection, branch);
@@ -130,20 +191,21 @@ class AdminFirestoreTransactionHandle implements FirestoreTransactionHandle {
         : sliced;
     }
 
-    // Mirror the non-transactional fast path: when there are no post-filters,
-    // push orderBy + limit(skip + take) so we don't lock the whole set.
     let query = buildCollectionQuery(this.db, collection, branch);
-    if (options.orderBy) {
-      for (const clause of options.orderBy) {
+    if (reconciled.serverOrderBy) {
+      for (const clause of reconciled.serverOrderBy) {
         query = query.orderBy(clause.field, clause.direction);
       }
     }
 
-    if (branch.postFilters.length > 0) {
+    if (!pushLimit) {
       const snapshot = await this.transaction.get(query);
       const rows = snapshot.docs.map((doc) => normalise(doc.data(), doc.id));
       const filtered = applyFirestorePostFilters(rows, branch.postFilters);
-      const sliced = filtered.slice(skip);
+      const ordered = reconciled.clientReorder
+        ? sortFirestoreRows(filtered, options.orderBy)
+        : filtered;
+      const sliced = ordered.slice(skip);
       return typeof take === 'number' && take > 0
         ? sliced.slice(0, take)
         : sliced;
@@ -230,11 +292,23 @@ export class AdminFirestoreBackend implements FirestoreBackend {
     documentId: string,
     data: Record<string, unknown>,
     merge = false,
+    precondition?: FirestoreWritePrecondition,
   ): Promise<void> {
-    await this.db()
-      .collection(collection)
-      .doc(documentId)
-      .set(serialise(data), { merge });
+    try {
+      const ref = this.db().collection(collection).doc(documentId);
+      const adminPrecondition = toAdminPrecondition(precondition);
+      // Precondition is only valid on update/delete in the Admin SDK.
+      if (adminPrecondition) {
+        await ref.update(serialise(data), adminPrecondition);
+        return;
+      }
+      await ref.set(serialise(data), { merge });
+    } catch (error) {
+      if (isFailedPreconditionError(error)) {
+        throw new FirestorePreconditionFailedException(collection, documentId);
+      }
+      throw error;
+    }
   }
 
   async create(
@@ -255,8 +329,25 @@ export class AdminFirestoreBackend implements FirestoreBackend {
     }
   }
 
-  async delete(collection: string, documentId: string): Promise<void> {
-    await this.db().collection(collection).doc(documentId).delete();
+  async delete(
+    collection: string,
+    documentId: string,
+    precondition?: FirestoreWritePrecondition,
+  ): Promise<void> {
+    try {
+      const ref = this.db().collection(collection).doc(documentId);
+      const adminPrecondition = toAdminPrecondition(precondition);
+      if (adminPrecondition) {
+        await ref.delete(adminPrecondition);
+      } else {
+        await ref.delete();
+      }
+    } catch (error) {
+      if (isFailedPreconditionError(error)) {
+        throw new FirestorePreconditionFailedException(collection, documentId);
+      }
+      throw error;
+    }
   }
 
   async queryBranch(
@@ -266,6 +357,9 @@ export class AdminFirestoreBackend implements FirestoreBackend {
     const branch = options.branch;
     const skip = options.skip ?? 0;
     const take = options.take;
+    const reconciled = reconcileOrderByWithInequality(branch, options.orderBy);
+    const pushLimit =
+      branch.postFilters.length === 0 && !reconciled.clientReorder;
 
     if (branch.documentId !== undefined || branch.documentIds !== undefined) {
       const rows = await this.loadBranchRows(collection, branch);
@@ -280,22 +374,29 @@ export class AdminFirestoreBackend implements FirestoreBackend {
         : sliced;
     }
 
-    // Post-filters require in-memory evaluation, so we cannot rely on
-    // server-side limit alone — read all matching docs and slice locally.
-    if (branch.postFilters.length > 0) {
-      const query = this.buildOrderedQuery(collection, branch, options.orderBy);
+    if (!pushLimit) {
+      const query = this.buildOrderedQuery(
+        collection,
+        branch,
+        reconciled.serverOrderBy,
+      );
       const snapshot = await query.get();
       const rows = snapshot.docs.map((doc) => normalise(doc.data(), doc.id));
       const filtered = applyFirestorePostFilters(rows, branch.postFilters);
-      const sliced = filtered.slice(skip);
+      const ordered = reconciled.clientReorder
+        ? sortFirestoreRows(filtered, options.orderBy)
+        : filtered;
+      const sliced = ordered.slice(skip);
       return typeof take === 'number' && take > 0
         ? sliced.slice(0, take)
         : sliced;
     }
 
-    // Fast path: push orderBy + limit(skip + take) to Firestore, slice(skip)
-    // locally. Reads are O(skip + take), not O(collection size).
-    let query = this.buildOrderedQuery(collection, branch, options.orderBy);
+    let query = this.buildOrderedQuery(
+      collection,
+      branch,
+      reconciled.serverOrderBy,
+    );
     if (typeof take === 'number' && take > 0) {
       query = query.limit(skip + take);
     }
@@ -332,6 +433,43 @@ export class AdminFirestoreBackend implements FirestoreBackend {
     return db.runTransaction(async (transaction) =>
       fn(new AdminFirestoreTransactionHandle(transaction, db)),
     );
+  }
+
+  async writeBatch(
+    operations: readonly FirestoreBatchOperation[],
+  ): Promise<void> {
+    if (operations.length === 0) {
+      return;
+    }
+    if (operations.length > FIRESTORE_MAX_BATCH_WRITES) {
+      throw new Error(
+        `Firestore writeBatch accepts at most ${FIRESTORE_MAX_BATCH_WRITES} operations (got ${operations.length})`,
+      );
+    }
+
+    const db = this.db();
+    const batch = db.batch();
+    for (const operation of operations) {
+      const ref = db.collection(operation.collection).doc(operation.id);
+      if (operation.op === 'create') {
+        batch.create(ref, serialise(operation.data));
+      } else {
+        batch.delete(ref);
+      }
+    }
+
+    try {
+      await batch.commit();
+    } catch (error) {
+      if (isAlreadyExistsError(error)) {
+        const createOp = operations.find((op) => op.op === 'create');
+        throw new FirestoreDuplicateIdException(
+          createOp?.collection ?? 'unknown',
+          createOp?.id ?? 'unknown',
+        );
+      }
+      throw error;
+    }
   }
 
   private async loadBranchRows(

--- a/packages/rockets-repository-firestore/src/backends/admin-firestore.backend.ts
+++ b/packages/rockets-repository-firestore/src/backends/admin-firestore.backend.ts
@@ -2,17 +2,18 @@ import { getApp } from 'firebase-admin/app';
 import {
   FieldValue,
   getFirestore,
-  Timestamp,
   type DocumentData,
   type Firestore,
-  type Precondition,
   type Query,
   type Transaction,
 } from 'firebase-admin/firestore';
 
 import { FIRESTORE_MAX_BATCH_WRITES } from '../constants/firestore-transaction.constants';
+import { FirestoreBatchWriteLimitExceededException } from '../exceptions/firestore-batch-write-limit-exceeded.exception';
 import { FirestoreDuplicateIdException } from '../exceptions/firestore-duplicate-id.exception';
+import { FirestoreInvalidPreconditionException } from '../exceptions/firestore-invalid-precondition.exception';
 import { FirestorePreconditionFailedException } from '../exceptions/firestore-precondition-failed.exception';
+import { FirestoreTransactionReadAfterWriteException } from '../exceptions/firestore-transaction-read-after-write.exception';
 import type {
   FirestoreBackend,
   FirestoreBatchOperation,
@@ -32,28 +33,61 @@ import { applyFirestoreFilters } from '../repository/firestore-row-filter';
 import { sortFirestoreRows } from '../repository/firestore-sort';
 import { normalizeFirestoreValue } from '../repository/firestore-value';
 import { FirestoreTransactionWriteCounter } from '../transaction/firestore-transaction-write-counter';
+import { toAdminPrecondition } from '../utils/firestore-precondition.util';
 
 const GET_ALL_CHUNK = 300;
 
+const GRPC_NOT_FOUND = 5;
 const GRPC_ALREADY_EXISTS = 6;
 const GRPC_FAILED_PRECONDITION = 9;
 
-function isAlreadyExistsError(error: unknown): boolean {
+function isGrpcCode(error: unknown, code: number): boolean {
   return (
     typeof error === 'object' &&
     error !== null &&
     'code' in error &&
-    error.code === GRPC_ALREADY_EXISTS
+    error.code === code
   );
 }
 
+function isAlreadyExistsError(error: unknown): boolean {
+  return isGrpcCode(error, GRPC_ALREADY_EXISTS);
+}
+
 function isFailedPreconditionError(error: unknown): boolean {
+  return isGrpcCode(error, GRPC_FAILED_PRECONDITION);
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return isGrpcCode(error, GRPC_NOT_FOUND);
+}
+
+function isPreconditionedWriteFailure(
+  error: unknown,
+  precondition: FirestoreWritePrecondition | undefined,
+): boolean {
   return (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    error.code === GRPC_FAILED_PRECONDITION
+    isFailedPreconditionError(error) ||
+    (precondition !== undefined && isNotFoundError(error))
   );
+}
+
+function isReadAfterWriteError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return /all reads before all writes/i.test(error.message);
+}
+
+async function mapTransactionRead<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    if (isReadAfterWriteError(error)) {
+      throw new FirestoreTransactionReadAfterWriteException();
+    }
+    throw error;
+  }
 }
 
 function serialise(data: Record<string, unknown>): Record<string, unknown> {
@@ -66,23 +100,6 @@ function serialise(data: Record<string, unknown>): Record<string, unknown> {
     }
   }
   return next;
-}
-
-function toAdminPrecondition(
-  precondition: FirestoreWritePrecondition | undefined,
-): Precondition | undefined {
-  if (precondition === undefined) {
-    return undefined;
-  }
-  if (precondition.lastUpdateTime !== undefined) {
-    return {
-      lastUpdateTime: Timestamp.fromDate(precondition.lastUpdateTime),
-    };
-  }
-  if (precondition.exists !== undefined) {
-    return { exists: precondition.exists };
-  }
-  return undefined;
 }
 
 function normalise(
@@ -111,24 +128,29 @@ class AdminFirestoreTransactionHandle implements FirestoreTransactionHandle {
     collection: string,
     documentId: string,
   ): Promise<Record<string, unknown> | null> {
-    const snap = await this.transaction.get(
-      this.db.collection(collection).doc(documentId),
-    );
-    if (!snap.exists) {
-      return null;
-    }
-    return normalise(snap.data(), documentId);
+    return mapTransactionRead(async () => {
+      const snap = await this.transaction.get(
+        this.db.collection(collection).doc(documentId),
+      );
+      if (!snap.exists) {
+        return null;
+      }
+      return normalise(snap.data(), documentId);
+    });
   }
 
   async create(
     collection: string,
     documentId: string,
     data: Record<string, unknown>,
+    options?: { readonly skipExistenceRead?: boolean },
   ): Promise<void> {
     const ref = this.db.collection(collection).doc(documentId);
-    const snap = await this.transaction.get(ref);
-    if (snap.exists) {
-      throw new FirestoreDuplicateIdException(collection, documentId);
+    if (!options?.skipExistenceRead) {
+      const snap = await mapTransactionRead(() => this.transaction.get(ref));
+      if (snap.exists) {
+        throw new FirestoreDuplicateIdException(collection, documentId);
+      }
     }
     this.writes.recordWrite();
     this.transaction.create(ref, serialise(data));
@@ -143,9 +165,14 @@ class AdminFirestoreTransactionHandle implements FirestoreTransactionHandle {
   ): Promise<void> {
     this.writes.recordWrite();
     const ref = this.db.collection(collection).doc(documentId);
-    const adminPrecondition = toAdminPrecondition(precondition);
+    const adminPrecondition = toAdminPrecondition(precondition, 'set');
     // Precondition is only valid on update/delete in the Admin SDK.
     if (adminPrecondition) {
+      if (!merge) {
+        throw new FirestoreInvalidPreconditionException(
+          'Firestore preconditioned set requires merge: true (update semantics)',
+        );
+      }
       this.transaction.update(ref, serialise(data), adminPrecondition);
       return;
     }
@@ -159,7 +186,7 @@ class AdminFirestoreTransactionHandle implements FirestoreTransactionHandle {
   ): Promise<void> {
     this.writes.recordWrite();
     const ref = this.db.collection(collection).doc(documentId);
-    const adminPrecondition = toAdminPrecondition(precondition);
+    const adminPrecondition = toAdminPrecondition(precondition, 'delete');
     if (adminPrecondition) {
       this.transaction.delete(ref, adminPrecondition);
     } else {
@@ -168,6 +195,15 @@ class AdminFirestoreTransactionHandle implements FirestoreTransactionHandle {
   }
 
   async queryBranch(
+    collection: string,
+    options: FirestoreBranchQueryOptions,
+  ): Promise<Record<string, unknown>[]> {
+    return mapTransactionRead(() =>
+      this.queryBranchUnmapped(collection, options),
+    );
+  }
+
+  private async queryBranchUnmapped(
     collection: string,
     options: FirestoreBranchQueryOptions,
   ): Promise<Record<string, unknown>[]> {
@@ -296,15 +332,23 @@ export class AdminFirestoreBackend implements FirestoreBackend {
   ): Promise<void> {
     try {
       const ref = this.db().collection(collection).doc(documentId);
-      const adminPrecondition = toAdminPrecondition(precondition);
+      const adminPrecondition = toAdminPrecondition(precondition, 'set');
       // Precondition is only valid on update/delete in the Admin SDK.
       if (adminPrecondition) {
+        if (!merge) {
+          throw new FirestoreInvalidPreconditionException(
+            'Firestore preconditioned set requires merge: true (update semantics)',
+          );
+        }
         await ref.update(serialise(data), adminPrecondition);
         return;
       }
       await ref.set(serialise(data), { merge });
     } catch (error) {
-      if (isFailedPreconditionError(error)) {
+      if (error instanceof FirestoreInvalidPreconditionException) {
+        throw error;
+      }
+      if (isPreconditionedWriteFailure(error, precondition)) {
         throw new FirestorePreconditionFailedException(collection, documentId);
       }
       throw error;
@@ -315,6 +359,7 @@ export class AdminFirestoreBackend implements FirestoreBackend {
     collection: string,
     documentId: string,
     data: Record<string, unknown>,
+    _options?: { readonly skipExistenceRead?: boolean },
   ): Promise<void> {
     try {
       await this.db()
@@ -336,14 +381,14 @@ export class AdminFirestoreBackend implements FirestoreBackend {
   ): Promise<void> {
     try {
       const ref = this.db().collection(collection).doc(documentId);
-      const adminPrecondition = toAdminPrecondition(precondition);
+      const adminPrecondition = toAdminPrecondition(precondition, 'delete');
       if (adminPrecondition) {
         await ref.delete(adminPrecondition);
       } else {
         await ref.delete();
       }
     } catch (error) {
-      if (isFailedPreconditionError(error)) {
+      if (isPreconditionedWriteFailure(error, precondition)) {
         throw new FirestorePreconditionFailedException(collection, documentId);
       }
       throw error;
@@ -442,9 +487,7 @@ export class AdminFirestoreBackend implements FirestoreBackend {
       return;
     }
     if (operations.length > FIRESTORE_MAX_BATCH_WRITES) {
-      throw new Error(
-        `Firestore writeBatch accepts at most ${FIRESTORE_MAX_BATCH_WRITES} operations (got ${operations.length})`,
-      );
+      throw new FirestoreBatchWriteLimitExceededException(operations.length);
     }
 
     const db = this.db();
@@ -462,10 +505,18 @@ export class AdminFirestoreBackend implements FirestoreBackend {
       await batch.commit();
     } catch (error) {
       if (isAlreadyExistsError(error)) {
-        const createOp = operations.find((op) => op.op === 'create');
+        const createOps = operations.filter((op) => op.op === 'create');
+        // Admin batch.commit does not say which create collided; only name
+        // the id when the batch had a single create.
+        if (createOps.length === 1) {
+          throw new FirestoreDuplicateIdException(
+            createOps[0].collection,
+            createOps[0].id,
+          );
+        }
         throw new FirestoreDuplicateIdException(
-          createOp?.collection ?? 'unknown',
-          createOp?.id ?? 'unknown',
+          createOps[0]?.collection ?? 'unknown',
+          'unknown',
         );
       }
       throw error;

--- a/packages/rockets-repository-firestore/src/backends/admin-firestore.backend.ts
+++ b/packages/rockets-repository-firestore/src/backends/admin-firestore.backend.ts
@@ -2,7 +2,9 @@ import { getApp } from 'firebase-admin/app';
 import {
   getFirestore,
   type DocumentData,
+  type Firestore,
   type Query,
+  type Transaction,
 } from 'firebase-admin/firestore';
 
 import { FirestoreDuplicateIdException } from '../exceptions/firestore-duplicate-id.exception';
@@ -15,6 +17,7 @@ import type {
   FirestoreOrderBy,
   FirestoreQueryBranch,
 } from '../interfaces/firestore-query.interface';
+import type { FirestoreTransactionHandle } from '../interfaces/firestore-transaction-handle.interface';
 import { applyFirestorePostFilters } from '../repository/firestore-post-filter';
 import { applyFirestoreFilters } from '../repository/firestore-row-filter';
 import { sortFirestoreRows } from '../repository/firestore-sort';
@@ -34,6 +37,178 @@ function isAlreadyExistsError(error: unknown): boolean {
   );
 }
 
+function serialise(data: Record<string, unknown>): Record<string, unknown> {
+  return { ...data };
+}
+
+function normalise(
+  data: DocumentData | undefined,
+  documentId: string,
+): Record<string, unknown> {
+  if (!data) {
+    return { id: documentId };
+  }
+  const next: Record<string, unknown> = { id: documentId };
+  for (const [key, value] of Object.entries(data)) {
+    next[key] = normalizeFirestoreValue(value);
+  }
+  return next;
+}
+
+class AdminFirestoreTransactionHandle implements FirestoreTransactionHandle {
+  constructor(
+    private readonly transaction: Transaction,
+    private readonly db: Firestore,
+  ) {}
+
+  async get(
+    collection: string,
+    documentId: string,
+  ): Promise<Record<string, unknown> | null> {
+    const snap = await this.transaction.get(
+      this.db.collection(collection).doc(documentId),
+    );
+    if (!snap.exists) {
+      return null;
+    }
+    return normalise(snap.data(), documentId);
+  }
+
+  async create(
+    collection: string,
+    documentId: string,
+    data: Record<string, unknown>,
+  ): Promise<void> {
+    // ALREADY_EXISTS for transaction.create() surfaces at commit, not at
+    // enqueue — so read first and throw the adapter's 409 shape here. Under
+    // contention Firestore retries the whole attempt; the loser then sees
+    // the winner's doc and gets FirestoreDuplicateIdException instead of a
+    // raw gRPC error.
+    const ref = this.db.collection(collection).doc(documentId);
+    const snap = await this.transaction.get(ref);
+    if (snap.exists) {
+      throw new FirestoreDuplicateIdException(collection, documentId);
+    }
+    this.transaction.create(ref, serialise(data));
+  }
+
+  async set(
+    collection: string,
+    documentId: string,
+    data: Record<string, unknown>,
+    merge = false,
+  ): Promise<void> {
+    this.transaction.set(
+      this.db.collection(collection).doc(documentId),
+      serialise(data),
+      { merge },
+    );
+  }
+
+  async delete(collection: string, documentId: string): Promise<void> {
+    this.transaction.delete(this.db.collection(collection).doc(documentId));
+  }
+
+  async queryBranch(
+    collection: string,
+    options: FirestoreBranchQueryOptions,
+  ): Promise<Record<string, unknown>[]> {
+    const branch = options.branch;
+    const skip = options.skip ?? 0;
+    const take = options.take;
+
+    if (branch.documentId !== undefined || branch.documentIds !== undefined) {
+      const rows = await this.loadBranchRows(collection, branch);
+      const filtered = applyFirestorePostFilters(
+        applyFirestoreFilters(rows, branch.filters),
+        branch.postFilters,
+      );
+      const ordered = sortFirestoreRows(filtered, options.orderBy);
+      const sliced = ordered.slice(skip);
+      return typeof take === 'number' && take > 0
+        ? sliced.slice(0, take)
+        : sliced;
+    }
+
+    // Mirror the non-transactional fast path: when there are no post-filters,
+    // push orderBy + limit(skip + take) so we don't lock the whole set.
+    let query = buildCollectionQuery(this.db, collection, branch);
+    if (options.orderBy) {
+      for (const clause of options.orderBy) {
+        query = query.orderBy(clause.field, clause.direction);
+      }
+    }
+
+    if (branch.postFilters.length > 0) {
+      const snapshot = await this.transaction.get(query);
+      const rows = snapshot.docs.map((doc) => normalise(doc.data(), doc.id));
+      const filtered = applyFirestorePostFilters(rows, branch.postFilters);
+      const sliced = filtered.slice(skip);
+      return typeof take === 'number' && take > 0
+        ? sliced.slice(0, take)
+        : sliced;
+    }
+
+    if (typeof take === 'number' && take > 0) {
+      query = query.limit(skip + take);
+    }
+    const snapshot = await this.transaction.get(query);
+    const rows = snapshot.docs.map((doc) => normalise(doc.data(), doc.id));
+    return skip > 0 ? rows.slice(skip) : rows;
+  }
+
+  async countBranch(
+    collection: string,
+    branch: FirestoreQueryBranch,
+  ): Promise<number> {
+    const rows = await this.queryBranch(collection, { branch });
+    return rows.length;
+  }
+
+  private async loadBranchRows(
+    collection: string,
+    branch: FirestoreQueryBranch,
+  ): Promise<Record<string, unknown>[]> {
+    if (branch.documentId !== undefined) {
+      const row = await this.get(collection, branch.documentId);
+      return row ? [row] : [];
+    }
+
+    if (branch.documentIds !== undefined) {
+      const rows: Record<string, unknown>[] = [];
+      for (const documentId of branch.documentIds) {
+        const row = await this.get(collection, documentId);
+        if (row) {
+          rows.push(row);
+        }
+      }
+      return rows;
+    }
+
+    const query = buildCollectionQuery(this.db, collection, branch);
+    const snapshot = await this.transaction.get(query);
+    return snapshot.docs.map((doc) => normalise(doc.data(), doc.id));
+  }
+}
+
+function buildCollectionQuery(
+  db: Firestore,
+  collection: string,
+  branch: FirestoreQueryBranch,
+): Query {
+  let query: Query = db.collection(collection);
+
+  for (const filter of branch.filters) {
+    query = query.where(
+      filter.field,
+      filter.op as FirestoreFilterOp,
+      filter.value,
+    );
+  }
+
+  return query;
+}
+
 export class AdminFirestoreBackend implements FirestoreBackend {
   private db() {
     return getFirestore(getApp());
@@ -47,7 +222,7 @@ export class AdminFirestoreBackend implements FirestoreBackend {
     if (!snap.exists) {
       return null;
     }
-    return this.normalise(snap.data(), documentId);
+    return normalise(snap.data(), documentId);
   }
 
   async set(
@@ -59,7 +234,7 @@ export class AdminFirestoreBackend implements FirestoreBackend {
     await this.db()
       .collection(collection)
       .doc(documentId)
-      .set(this.serialise(data), { merge });
+      .set(serialise(data), { merge });
   }
 
   async create(
@@ -71,7 +246,7 @@ export class AdminFirestoreBackend implements FirestoreBackend {
       await this.db()
         .collection(collection)
         .doc(documentId)
-        .create(this.serialise(data));
+        .create(serialise(data));
     } catch (error) {
       if (isAlreadyExistsError(error)) {
         throw new FirestoreDuplicateIdException(collection, documentId);
@@ -110,9 +285,7 @@ export class AdminFirestoreBackend implements FirestoreBackend {
     if (branch.postFilters.length > 0) {
       const query = this.buildOrderedQuery(collection, branch, options.orderBy);
       const snapshot = await query.get();
-      const rows = snapshot.docs.map((doc) =>
-        this.normalise(doc.data(), doc.id),
-      );
+      const rows = snapshot.docs.map((doc) => normalise(doc.data(), doc.id));
       const filtered = applyFirestorePostFilters(rows, branch.postFilters);
       const sliced = filtered.slice(skip);
       return typeof take === 'number' && take > 0
@@ -127,7 +300,7 @@ export class AdminFirestoreBackend implements FirestoreBackend {
       query = query.limit(skip + take);
     }
     const snapshot = await query.get();
-    const rows = snapshot.docs.map((doc) => this.normalise(doc.data(), doc.id));
+    const rows = snapshot.docs.map((doc) => normalise(doc.data(), doc.id));
     return skip > 0 ? rows.slice(skip) : rows;
   }
 
@@ -147,9 +320,18 @@ export class AdminFirestoreBackend implements FirestoreBackend {
       ).length;
     }
 
-    const query = this.buildCollectionQuery(collection, branch);
+    const query = buildCollectionQuery(this.db(), collection, branch);
     const snapshot = await query.count().get();
     return snapshot.data().count;
+  }
+
+  async runTransaction<T>(
+    fn: (tx: FirestoreTransactionHandle) => Promise<T>,
+  ): Promise<T> {
+    const db = this.db();
+    return db.runTransaction(async (transaction) =>
+      fn(new AdminFirestoreTransactionHandle(transaction, db)),
+    );
   }
 
   private async loadBranchRows(
@@ -176,33 +358,16 @@ export class AdminFirestoreBackend implements FirestoreBackend {
         const snapshots = await this.db().getAll(...refs);
         for (const snapshot of snapshots) {
           if (snapshot.exists) {
-            rows.push(this.normalise(snapshot.data(), snapshot.id));
+            rows.push(normalise(snapshot.data(), snapshot.id));
           }
         }
       }
       return rows;
     }
 
-    const query = this.buildCollectionQuery(collection, branch);
+    const query = buildCollectionQuery(this.db(), collection, branch);
     const snapshot = await query.get();
-    return snapshot.docs.map((doc) => this.normalise(doc.data(), doc.id));
-  }
-
-  private buildCollectionQuery(
-    collection: string,
-    branch: FirestoreQueryBranch,
-  ): Query {
-    let query: Query = this.db().collection(collection);
-
-    for (const filter of branch.filters) {
-      query = query.where(
-        filter.field,
-        filter.op as FirestoreFilterOp,
-        filter.value,
-      );
-    }
-
-    return query;
+    return snapshot.docs.map((doc) => normalise(doc.data(), doc.id));
   }
 
   private buildOrderedQuery(
@@ -210,36 +375,12 @@ export class AdminFirestoreBackend implements FirestoreBackend {
     branch: FirestoreQueryBranch,
     orderBy: readonly FirestoreOrderBy[] | undefined,
   ): Query {
-    let query = this.buildCollectionQuery(collection, branch);
+    let query = buildCollectionQuery(this.db(), collection, branch);
     if (orderBy) {
       for (const clause of orderBy) {
         query = query.orderBy(clause.field, clause.direction);
       }
     }
     return query;
-  }
-
-  /**
-   * `Date` goes to the SDK untouched: Firestore stores it as a native
-   * `Timestamp`, which {@link normalise} converts straight back to a
-   * `Date`. Stringifying here is what made that round trip lossy and
-   * left `normalise`'s `instanceof Timestamp` branch permanently dead.
-   */
-  private serialise(data: Record<string, unknown>): Record<string, unknown> {
-    return { ...data };
-  }
-
-  private normalise(
-    data: DocumentData | undefined,
-    documentId: string,
-  ): Record<string, unknown> {
-    if (!data) {
-      return { id: documentId };
-    }
-    const next: Record<string, unknown> = { id: documentId };
-    for (const [key, value] of Object.entries(data)) {
-      next[key] = normalizeFirestoreValue(value);
-    }
-    return next;
   }
 }

--- a/packages/rockets-repository-firestore/src/backends/in-memory-firestore.backend.ts
+++ b/packages/rockets-repository-firestore/src/backends/in-memory-firestore.backend.ts
@@ -1,6 +1,9 @@
 import { FIRESTORE_MAX_BATCH_WRITES } from '../constants/firestore-transaction.constants';
+import { FirestoreBatchWriteLimitExceededException } from '../exceptions/firestore-batch-write-limit-exceeded.exception';
 import { FirestoreDuplicateIdException } from '../exceptions/firestore-duplicate-id.exception';
+import { FirestoreInvalidPreconditionException } from '../exceptions/firestore-invalid-precondition.exception';
 import { FirestorePreconditionFailedException } from '../exceptions/firestore-precondition-failed.exception';
+import { FirestoreTransactionReadAfterWriteException } from '../exceptions/firestore-transaction-read-after-write.exception';
 import type {
   FirestoreBackend,
   FirestoreBatchOperation,
@@ -73,14 +76,35 @@ function assertPrecondition(
   documentId: string,
   existing: StoredDocument | undefined,
   precondition: FirestoreWritePrecondition | undefined,
+  mode: 'set' | 'delete',
 ): void {
   if (precondition === undefined) {
     return;
   }
-  if (precondition.exists === true && existing === undefined) {
+  if (
+    precondition.lastUpdateTime !== undefined &&
+    precondition.exists !== undefined
+  ) {
+    throw new FirestoreInvalidPreconditionException(
+      'Firestore precondition cannot set both lastUpdateTime and exists',
+    );
+  }
+  if (precondition.exists === false) {
+    if (mode === 'set') {
+      throw new FirestoreInvalidPreconditionException(
+        'Firestore set/update precondition cannot require exists: false — use create()',
+      );
+    }
+    if (existing !== undefined) {
+      throw new FirestorePreconditionFailedException(collection, documentId);
+    }
+    return;
+  }
+  // Preconditioned set uses update semantics — document must exist.
+  if (mode === 'set' && existing === undefined) {
     throw new FirestorePreconditionFailedException(collection, documentId);
   }
-  if (precondition.exists === false && existing !== undefined) {
+  if (precondition.exists === true && existing === undefined) {
     throw new FirestorePreconditionFailedException(collection, documentId);
   }
   if (
@@ -112,9 +136,12 @@ class InMemoryFirestoreTransactionHandle implements FirestoreTransactionHandle {
     collection: string,
     documentId: string,
     data: Record<string, unknown>,
+    options?: { readonly skipExistenceRead?: boolean },
   ): Promise<void> {
-    this.assertReadable();
     const store = collectionStore(this.stores, collection);
+    if (!options?.skipExistenceRead) {
+      this.assertReadable();
+    }
     if (store.has(documentId)) {
       throw new FirestoreDuplicateIdException(collection, documentId);
     }
@@ -135,7 +162,12 @@ class InMemoryFirestoreTransactionHandle implements FirestoreTransactionHandle {
   ): Promise<void> {
     const store = collectionStore(this.stores, collection);
     const current = store.get(documentId);
-    assertPrecondition(collection, documentId, current, precondition);
+    if (precondition !== undefined && !merge) {
+      throw new FirestoreInvalidPreconditionException(
+        'Firestore preconditioned set requires merge: true (update semantics)',
+      );
+    }
+    assertPrecondition(collection, documentId, current, precondition, 'set');
     this.writes.recordWrite();
     store.set(documentId, {
       data: {
@@ -158,6 +190,7 @@ class InMemoryFirestoreTransactionHandle implements FirestoreTransactionHandle {
       documentId,
       store.get(documentId),
       precondition,
+      'delete',
     );
     this.writes.recordWrite();
     store.delete(documentId);
@@ -194,9 +227,7 @@ class InMemoryFirestoreTransactionHandle implements FirestoreTransactionHandle {
 
   private assertReadable(): void {
     if (this.wrote) {
-      throw new Error(
-        'Firestore transactions require all reads before all writes',
-      );
+      throw new FirestoreTransactionReadAfterWriteException();
     }
   }
 
@@ -259,7 +290,12 @@ export class InMemoryFirestoreBackend implements FirestoreBackend {
   ): Promise<void> {
     const store = this.rootCollectionStore(collection);
     const current = store.get(documentId);
-    assertPrecondition(collection, documentId, current, precondition);
+    if (precondition !== undefined && !merge) {
+      throw new FirestoreInvalidPreconditionException(
+        'Firestore preconditioned set requires merge: true (update semantics)',
+      );
+    }
+    assertPrecondition(collection, documentId, current, precondition, 'set');
     store.set(documentId, {
       data: {
         ...applyWriteData(current?.data, data, merge),
@@ -274,6 +310,7 @@ export class InMemoryFirestoreBackend implements FirestoreBackend {
     collection: string,
     documentId: string,
     data: Record<string, unknown>,
+    _options?: { readonly skipExistenceRead?: boolean },
   ): Promise<void> {
     const store = this.rootCollectionStore(collection);
     if (store.has(documentId)) {
@@ -297,6 +334,7 @@ export class InMemoryFirestoreBackend implements FirestoreBackend {
       documentId,
       store.get(documentId),
       precondition,
+      'delete',
     );
     store.delete(documentId);
     this.generation += 1;
@@ -356,9 +394,7 @@ export class InMemoryFirestoreBackend implements FirestoreBackend {
       return;
     }
     if (operations.length > FIRESTORE_MAX_BATCH_WRITES) {
-      throw new Error(
-        `Firestore writeBatch accepts at most ${FIRESTORE_MAX_BATCH_WRITES} operations (got ${operations.length})`,
-      );
+      throw new FirestoreBatchWriteLimitExceededException(operations.length);
     }
 
     const working = cloneStores(this.stores);

--- a/packages/rockets-repository-firestore/src/backends/in-memory-firestore.backend.ts
+++ b/packages/rockets-repository-firestore/src/backends/in-memory-firestore.backend.ts
@@ -54,6 +54,11 @@ class InMemoryFirestoreTransactionHandle implements FirestoreTransactionHandle {
     documentId: string,
     data: Record<string, unknown>,
   ): Promise<void> {
+    // The Admin handle reads the document before enqueueing the create (to
+    // raise the adapter's 409 instead of a commit-time gRPC error), so this
+    // counts as a read and Firestore rejects it after any write. Enforce the
+    // same rule here or the double hides an INVALID_ARGUMENT in production.
+    this.assertReadable();
     const store = collectionStore(this.stores, collection);
     if (store.has(documentId)) {
       throw new FirestoreDuplicateIdException(collection, documentId);

--- a/packages/rockets-repository-firestore/src/backends/in-memory-firestore.backend.ts
+++ b/packages/rockets-repository-firestore/src/backends/in-memory-firestore.backend.ts
@@ -4,9 +4,143 @@ import type {
   FirestoreBranchQueryOptions,
 } from '../interfaces/firestore-backend.interface';
 import type { FirestoreQueryBranch } from '../interfaces/firestore-query.interface';
+import type { FirestoreTransactionHandle } from '../interfaces/firestore-transaction-handle.interface';
 import { applyFirestorePostFilters } from '../repository/firestore-post-filter';
 import { applyFirestoreFilters } from '../repository/firestore-row-filter';
 import { sortFirestoreRows } from '../repository/firestore-sort';
+
+type CollectionStore = Map<string, Record<string, unknown>>;
+type StoreMap = Map<string, CollectionStore>;
+
+function cloneStores(source: StoreMap): StoreMap {
+  const next: StoreMap = new Map();
+  for (const [collection, docs] of source) {
+    const cloned: CollectionStore = new Map();
+    for (const [id, row] of docs) {
+      cloned.set(id, { ...row });
+    }
+    next.set(collection, cloned);
+  }
+  return next;
+}
+
+function collectionStore(
+  stores: StoreMap,
+  collection: string,
+): CollectionStore {
+  let store = stores.get(collection);
+  if (!store) {
+    store = new Map();
+    stores.set(collection, store);
+  }
+  return store;
+}
+
+class InMemoryFirestoreTransactionHandle implements FirestoreTransactionHandle {
+  private wrote = false;
+
+  constructor(private readonly stores: StoreMap) {}
+
+  async get(
+    collection: string,
+    documentId: string,
+  ): Promise<Record<string, unknown> | null> {
+    this.assertReadable();
+    return collectionStore(this.stores, collection).get(documentId) ?? null;
+  }
+
+  async create(
+    collection: string,
+    documentId: string,
+    data: Record<string, unknown>,
+  ): Promise<void> {
+    const store = collectionStore(this.stores, collection);
+    if (store.has(documentId)) {
+      throw new FirestoreDuplicateIdException(collection, documentId);
+    }
+    store.set(documentId, { ...data, id: documentId });
+    this.wrote = true;
+  }
+
+  async set(
+    collection: string,
+    documentId: string,
+    data: Record<string, unknown>,
+    merge = false,
+  ): Promise<void> {
+    const store = collectionStore(this.stores, collection);
+    const current = store.get(documentId);
+    store.set(
+      documentId,
+      merge && current ? { ...current, ...data } : { ...data, id: documentId },
+    );
+    this.wrote = true;
+  }
+
+  async delete(collection: string, documentId: string): Promise<void> {
+    collectionStore(this.stores, collection).delete(documentId);
+    this.wrote = true;
+  }
+
+  async queryBranch(
+    collection: string,
+    options: FirestoreBranchQueryOptions,
+  ): Promise<Record<string, unknown>[]> {
+    this.assertReadable();
+    const rows = await this.loadBranchRows(collection, options.branch);
+    const filtered = applyFirestorePostFilters(
+      applyFirestoreFilters(rows, options.branch.filters),
+      options.branch.postFilters,
+    );
+    const ordered = sortFirestoreRows(filtered, options.orderBy);
+
+    const sliced = ordered.slice(options.skip ?? 0);
+    if (typeof options.take === 'number' && options.take > 0) {
+      return sliced.slice(0, options.take);
+    }
+    return sliced;
+  }
+
+  async countBranch(
+    collection: string,
+    branch: FirestoreQueryBranch,
+  ): Promise<number> {
+    this.assertReadable();
+    const rows = await this.queryBranch(collection, { branch });
+    return rows.length;
+  }
+
+  private assertReadable(): void {
+    if (this.wrote) {
+      throw new Error(
+        'Firestore transactions require all reads before all writes',
+      );
+    }
+  }
+
+  private async loadBranchRows(
+    collection: string,
+    branch: FirestoreQueryBranch,
+  ): Promise<Record<string, unknown>[]> {
+    if (branch.documentId !== undefined) {
+      const row = await this.get(collection, branch.documentId);
+      return row ? [row] : [];
+    }
+
+    if (branch.documentIds !== undefined) {
+      const rows: Record<string, unknown>[] = [];
+      for (const documentId of branch.documentIds) {
+        const row = await this.get(collection, documentId);
+        if (row) {
+          rows.push(row);
+        }
+      }
+      return rows;
+    }
+
+    return [...collectionStore(this.stores, collection).values()];
+  }
+}
 
 /**
  * In-memory Firestore backend for unit tests and explicit test harnesses.
@@ -18,27 +152,18 @@ import { sortFirestoreRows } from '../repository/firestore-sort';
  * collection names.
  */
 export class InMemoryFirestoreBackend implements FirestoreBackend {
-  private readonly stores = new Map<
-    string,
-    Map<string, Record<string, unknown>>
-  >();
+  private stores: StoreMap = new Map();
+  private generation = 0;
 
-  private collectionStore(
-    collection: string,
-  ): Map<string, Record<string, unknown>> {
-    let store = this.stores.get(collection);
-    if (!store) {
-      store = new Map();
-      this.stores.set(collection, store);
-    }
-    return store;
+  private rootCollectionStore(collection: string): CollectionStore {
+    return collectionStore(this.stores, collection);
   }
 
   async get(
     collection: string,
     documentId: string,
   ): Promise<Record<string, unknown> | null> {
-    return this.collectionStore(collection).get(documentId) ?? null;
+    return this.rootCollectionStore(collection).get(documentId) ?? null;
   }
 
   async set(
@@ -47,12 +172,13 @@ export class InMemoryFirestoreBackend implements FirestoreBackend {
     data: Record<string, unknown>,
     merge = false,
   ): Promise<void> {
-    const store = this.collectionStore(collection);
+    const store = this.rootCollectionStore(collection);
     const current = store.get(documentId);
     store.set(
       documentId,
       merge && current ? { ...current, ...data } : { ...data, id: documentId },
     );
+    this.generation += 1;
   }
 
   async create(
@@ -60,15 +186,17 @@ export class InMemoryFirestoreBackend implements FirestoreBackend {
     documentId: string,
     data: Record<string, unknown>,
   ): Promise<void> {
-    const store = this.collectionStore(collection);
+    const store = this.rootCollectionStore(collection);
     if (store.has(documentId)) {
       throw new FirestoreDuplicateIdException(collection, documentId);
     }
     store.set(documentId, { ...data, id: documentId });
+    this.generation += 1;
   }
 
   async delete(collection: string, documentId: string): Promise<void> {
-    this.collectionStore(collection).delete(documentId);
+    this.rootCollectionStore(collection).delete(documentId);
+    this.generation += 1;
   }
 
   async queryBranch(
@@ -101,6 +229,23 @@ export class InMemoryFirestoreBackend implements FirestoreBackend {
     return filtered.length;
   }
 
+  async runTransaction<T>(
+    fn: (tx: FirestoreTransactionHandle) => Promise<T>,
+  ): Promise<T> {
+    const startedAt = this.generation;
+    const working = cloneStores(this.stores);
+    const handle = new InMemoryFirestoreTransactionHandle(working);
+    const result = await fn(handle);
+    if (this.generation !== startedAt) {
+      throw new Error(
+        'Firestore in-memory transaction conflict: store changed during the attempt',
+      );
+    }
+    this.stores = working;
+    this.generation += 1;
+    return result;
+  }
+
   private async loadBranchRows(
     collection: string,
     branch: FirestoreQueryBranch,
@@ -121,6 +266,6 @@ export class InMemoryFirestoreBackend implements FirestoreBackend {
       return rows;
     }
 
-    return [...this.collectionStore(collection).values()];
+    return [...this.rootCollectionStore(collection).values()];
   }
 }

--- a/packages/rockets-repository-firestore/src/backends/in-memory-firestore.backend.ts
+++ b/packages/rockets-repository-firestore/src/backends/in-memory-firestore.backend.ts
@@ -1,23 +1,37 @@
+import { FIRESTORE_MAX_BATCH_WRITES } from '../constants/firestore-transaction.constants';
 import { FirestoreDuplicateIdException } from '../exceptions/firestore-duplicate-id.exception';
+import { FirestorePreconditionFailedException } from '../exceptions/firestore-precondition-failed.exception';
 import type {
   FirestoreBackend,
+  FirestoreBatchOperation,
   FirestoreBranchQueryOptions,
 } from '../interfaces/firestore-backend.interface';
 import type { FirestoreQueryBranch } from '../interfaces/firestore-query.interface';
 import type { FirestoreTransactionHandle } from '../interfaces/firestore-transaction-handle.interface';
+import type { FirestoreWritePrecondition } from '../interfaces/firestore-write.interface';
+import { isFirestoreIncrementSentinel } from '../interfaces/firestore-write.interface';
 import { applyFirestorePostFilters } from '../repository/firestore-post-filter';
 import { applyFirestoreFilters } from '../repository/firestore-row-filter';
 import { sortFirestoreRows } from '../repository/firestore-sort';
+import { FirestoreTransactionWriteCounter } from '../transaction/firestore-transaction-write-counter';
 
-type CollectionStore = Map<string, Record<string, unknown>>;
-type StoreMap = Map<string, CollectionStore>;
+type TimedCollectionStore = Map<string, StoredDocument>;
+type TimedStoreMap = Map<string, TimedCollectionStore>;
 
-function cloneStores(source: StoreMap): StoreMap {
-  const next: StoreMap = new Map();
+interface StoredDocument {
+  readonly data: Record<string, unknown>;
+  readonly updateTime: Date;
+}
+
+function cloneStores(source: TimedStoreMap): TimedStoreMap {
+  const next: TimedStoreMap = new Map();
   for (const [collection, docs] of source) {
-    const cloned: CollectionStore = new Map();
+    const cloned: TimedCollectionStore = new Map();
     for (const [id, row] of docs) {
-      cloned.set(id, { ...row });
+      cloned.set(id, {
+        data: { ...row.data },
+        updateTime: new Date(row.updateTime.getTime()),
+      });
     }
     next.set(collection, cloned);
   }
@@ -25,9 +39,9 @@ function cloneStores(source: StoreMap): StoreMap {
 }
 
 function collectionStore(
-  stores: StoreMap,
+  stores: TimedStoreMap,
   collection: string,
-): CollectionStore {
+): TimedCollectionStore {
   let store = stores.get(collection);
   if (!store) {
     store = new Map();
@@ -36,17 +50,62 @@ function collectionStore(
   return store;
 }
 
+function applyWriteData(
+  current: Record<string, unknown> | undefined,
+  data: Record<string, unknown>,
+  merge: boolean,
+): Record<string, unknown> {
+  const base = merge && current ? { ...current } : {};
+  for (const [key, value] of Object.entries(data)) {
+    if (isFirestoreIncrementSentinel(value)) {
+      const existing = base[key];
+      const currentNumber = typeof existing === 'number' ? existing : 0;
+      base[key] = currentNumber + value.__firestoreIncrement;
+    } else {
+      base[key] = value;
+    }
+  }
+  return base;
+}
+
+function assertPrecondition(
+  collection: string,
+  documentId: string,
+  existing: StoredDocument | undefined,
+  precondition: FirestoreWritePrecondition | undefined,
+): void {
+  if (precondition === undefined) {
+    return;
+  }
+  if (precondition.exists === true && existing === undefined) {
+    throw new FirestorePreconditionFailedException(collection, documentId);
+  }
+  if (precondition.exists === false && existing !== undefined) {
+    throw new FirestorePreconditionFailedException(collection, documentId);
+  }
+  if (
+    precondition.lastUpdateTime !== undefined &&
+    (existing === undefined ||
+      existing.updateTime.getTime() !== precondition.lastUpdateTime.getTime())
+  ) {
+    throw new FirestorePreconditionFailedException(collection, documentId);
+  }
+}
+
 class InMemoryFirestoreTransactionHandle implements FirestoreTransactionHandle {
   private wrote = false;
+  private readonly writes = new FirestoreTransactionWriteCounter();
 
-  constructor(private readonly stores: StoreMap) {}
+  constructor(private readonly stores: TimedStoreMap) {}
 
   async get(
     collection: string,
     documentId: string,
   ): Promise<Record<string, unknown> | null> {
     this.assertReadable();
-    return collectionStore(this.stores, collection).get(documentId) ?? null;
+    return (
+      collectionStore(this.stores, collection).get(documentId)?.data ?? null
+    );
   }
 
   async create(
@@ -54,16 +113,16 @@ class InMemoryFirestoreTransactionHandle implements FirestoreTransactionHandle {
     documentId: string,
     data: Record<string, unknown>,
   ): Promise<void> {
-    // The Admin handle reads the document before enqueueing the create (to
-    // raise the adapter's 409 instead of a commit-time gRPC error), so this
-    // counts as a read and Firestore rejects it after any write. Enforce the
-    // same rule here or the double hides an INVALID_ARGUMENT in production.
     this.assertReadable();
     const store = collectionStore(this.stores, collection);
     if (store.has(documentId)) {
       throw new FirestoreDuplicateIdException(collection, documentId);
     }
-    store.set(documentId, { ...data, id: documentId });
+    this.writes.recordWrite();
+    store.set(documentId, {
+      data: applyWriteData(undefined, { ...data, id: documentId }, false),
+      updateTime: new Date(),
+    });
     this.wrote = true;
   }
 
@@ -72,18 +131,36 @@ class InMemoryFirestoreTransactionHandle implements FirestoreTransactionHandle {
     documentId: string,
     data: Record<string, unknown>,
     merge = false,
+    precondition?: FirestoreWritePrecondition,
   ): Promise<void> {
     const store = collectionStore(this.stores, collection);
     const current = store.get(documentId);
-    store.set(
-      documentId,
-      merge && current ? { ...current, ...data } : { ...data, id: documentId },
-    );
+    assertPrecondition(collection, documentId, current, precondition);
+    this.writes.recordWrite();
+    store.set(documentId, {
+      data: {
+        ...applyWriteData(current?.data, data, merge),
+        id: documentId,
+      },
+      updateTime: new Date(),
+    });
     this.wrote = true;
   }
 
-  async delete(collection: string, documentId: string): Promise<void> {
-    collectionStore(this.stores, collection).delete(documentId);
+  async delete(
+    collection: string,
+    documentId: string,
+    precondition?: FirestoreWritePrecondition,
+  ): Promise<void> {
+    const store = collectionStore(this.stores, collection);
+    assertPrecondition(
+      collection,
+      documentId,
+      store.get(documentId),
+      precondition,
+    );
+    this.writes.recordWrite();
+    store.delete(documentId);
     this.wrote = true;
   }
 
@@ -143,7 +220,9 @@ class InMemoryFirestoreTransactionHandle implements FirestoreTransactionHandle {
       return rows;
     }
 
-    return [...collectionStore(this.stores, collection).values()];
+    return [...collectionStore(this.stores, collection).values()].map(
+      (entry) => entry.data,
+    );
   }
 }
 
@@ -157,10 +236,10 @@ class InMemoryFirestoreTransactionHandle implements FirestoreTransactionHandle {
  * collection names.
  */
 export class InMemoryFirestoreBackend implements FirestoreBackend {
-  private stores: StoreMap = new Map();
+  private stores: TimedStoreMap = new Map();
   private generation = 0;
 
-  private rootCollectionStore(collection: string): CollectionStore {
+  private rootCollectionStore(collection: string): TimedCollectionStore {
     return collectionStore(this.stores, collection);
   }
 
@@ -168,7 +247,7 @@ export class InMemoryFirestoreBackend implements FirestoreBackend {
     collection: string,
     documentId: string,
   ): Promise<Record<string, unknown> | null> {
-    return this.rootCollectionStore(collection).get(documentId) ?? null;
+    return this.rootCollectionStore(collection).get(documentId)?.data ?? null;
   }
 
   async set(
@@ -176,13 +255,18 @@ export class InMemoryFirestoreBackend implements FirestoreBackend {
     documentId: string,
     data: Record<string, unknown>,
     merge = false,
+    precondition?: FirestoreWritePrecondition,
   ): Promise<void> {
     const store = this.rootCollectionStore(collection);
     const current = store.get(documentId);
-    store.set(
-      documentId,
-      merge && current ? { ...current, ...data } : { ...data, id: documentId },
-    );
+    assertPrecondition(collection, documentId, current, precondition);
+    store.set(documentId, {
+      data: {
+        ...applyWriteData(current?.data, data, merge),
+        id: documentId,
+      },
+      updateTime: new Date(),
+    });
     this.generation += 1;
   }
 
@@ -195,12 +279,26 @@ export class InMemoryFirestoreBackend implements FirestoreBackend {
     if (store.has(documentId)) {
       throw new FirestoreDuplicateIdException(collection, documentId);
     }
-    store.set(documentId, { ...data, id: documentId });
+    store.set(documentId, {
+      data: applyWriteData(undefined, { ...data, id: documentId }, false),
+      updateTime: new Date(),
+    });
     this.generation += 1;
   }
 
-  async delete(collection: string, documentId: string): Promise<void> {
-    this.rootCollectionStore(collection).delete(documentId);
+  async delete(
+    collection: string,
+    documentId: string,
+    precondition?: FirestoreWritePrecondition,
+  ): Promise<void> {
+    const store = this.rootCollectionStore(collection);
+    assertPrecondition(
+      collection,
+      documentId,
+      store.get(documentId),
+      precondition,
+    );
+    store.delete(documentId);
     this.generation += 1;
   }
 
@@ -251,6 +349,44 @@ export class InMemoryFirestoreBackend implements FirestoreBackend {
     return result;
   }
 
+  async writeBatch(
+    operations: readonly FirestoreBatchOperation[],
+  ): Promise<void> {
+    if (operations.length === 0) {
+      return;
+    }
+    if (operations.length > FIRESTORE_MAX_BATCH_WRITES) {
+      throw new Error(
+        `Firestore writeBatch accepts at most ${FIRESTORE_MAX_BATCH_WRITES} operations (got ${operations.length})`,
+      );
+    }
+
+    const working = cloneStores(this.stores);
+    for (const operation of operations) {
+      const store = collectionStore(working, operation.collection);
+      if (operation.op === 'create') {
+        if (store.has(operation.id)) {
+          throw new FirestoreDuplicateIdException(
+            operation.collection,
+            operation.id,
+          );
+        }
+        store.set(operation.id, {
+          data: applyWriteData(
+            undefined,
+            { ...operation.data, id: operation.id },
+            false,
+          ),
+          updateTime: new Date(),
+        });
+      } else {
+        store.delete(operation.id);
+      }
+    }
+    this.stores = working;
+    this.generation += 1;
+  }
+
   private async loadBranchRows(
     collection: string,
     branch: FirestoreQueryBranch,
@@ -271,6 +407,8 @@ export class InMemoryFirestoreBackend implements FirestoreBackend {
       return rows;
     }
 
-    return [...this.rootCollectionStore(collection).values()];
+    return [...this.rootCollectionStore(collection).values()].map(
+      (entry) => entry.data,
+    );
   }
 }

--- a/packages/rockets-repository-firestore/src/constants/firestore-repository.constants.ts
+++ b/packages/rockets-repository-firestore/src/constants/firestore-repository.constants.ts
@@ -1,1 +1,4 @@
 export const FIRESTORE_REPOSITORY_MODULE_NAME = 'firestore';
+
+/** DI token for the shared {@link FirestoreBackend} registered by `forFeature`. */
+export const FIRESTORE_BACKEND = Symbol('FIRESTORE_BACKEND');

--- a/packages/rockets-repository-firestore/src/constants/firestore-transaction.constants.ts
+++ b/packages/rockets-repository-firestore/src/constants/firestore-transaction.constants.ts
@@ -1,0 +1,1 @@
+export const FIRESTORE_DEFAULT_TRANSACTION_KEY = 'firestore:default';

--- a/packages/rockets-repository-firestore/src/constants/firestore-transaction.constants.ts
+++ b/packages/rockets-repository-firestore/src/constants/firestore-transaction.constants.ts
@@ -1,1 +1,7 @@
 export const FIRESTORE_DEFAULT_TRANSACTION_KEY = 'firestore:default';
+
+/** Firestore hard limit on writes in a single transaction attempt. */
+export const FIRESTORE_MAX_TRANSACTION_WRITES = 500;
+
+/** Firestore hard limit on operations in a single WriteBatch. */
+export const FIRESTORE_MAX_BATCH_WRITES = 500;

--- a/packages/rockets-repository-firestore/src/exceptions/firestore-batch-write-limit-exceeded.exception.ts
+++ b/packages/rockets-repository-firestore/src/exceptions/firestore-batch-write-limit-exceeded.exception.ts
@@ -1,0 +1,23 @@
+import type { RuntimeExceptionOptions } from '@concepta/nestjs-core';
+import { HttpStatus } from '@nestjs/common';
+import { RepositoryQueryException } from '@concepta/nestjs-repository';
+
+import { FIRESTORE_MAX_BATCH_WRITES } from '../constants/firestore-transaction.constants';
+
+/**
+ * Thrown when a WriteBatch exceeds Firestore's per-batch operation limit.
+ */
+export class FirestoreBatchWriteLimitExceededException extends RepositoryQueryException {
+  constructor(
+    operationCount: number = FIRESTORE_MAX_BATCH_WRITES + 1,
+    options?: RuntimeExceptionOptions,
+  ) {
+    super('firestore-batch', {
+      message: `Firestore writeBatch accepts at most ${FIRESTORE_MAX_BATCH_WRITES} operations (got ${operationCount})`,
+      messageParams: [],
+      httpStatus: HttpStatus.BAD_REQUEST,
+      ...options,
+    });
+    this.errorCode = 'FIRESTORE_BATCH_WRITE_LIMIT_EXCEEDED';
+  }
+}

--- a/packages/rockets-repository-firestore/src/exceptions/firestore-invalid-document-id.exception.ts
+++ b/packages/rockets-repository-firestore/src/exceptions/firestore-invalid-document-id.exception.ts
@@ -1,0 +1,18 @@
+import type { RuntimeExceptionOptions } from '@concepta/nestjs-core';
+import { HttpStatus } from '@nestjs/common';
+import { RepositoryQueryException } from '@concepta/nestjs-repository';
+
+/**
+ * Thrown when a uniqueDocumentIdField value cannot become a Firestore doc id.
+ */
+export class FirestoreInvalidDocumentIdException extends RepositoryQueryException {
+  constructor(message: string, options?: RuntimeExceptionOptions) {
+    super('firestore-document-id', {
+      message,
+      messageParams: [],
+      httpStatus: HttpStatus.BAD_REQUEST,
+      ...options,
+    });
+    this.errorCode = 'FIRESTORE_INVALID_DOCUMENT_ID';
+  }
+}

--- a/packages/rockets-repository-firestore/src/exceptions/firestore-invalid-precondition.exception.ts
+++ b/packages/rockets-repository-firestore/src/exceptions/firestore-invalid-precondition.exception.ts
@@ -1,0 +1,19 @@
+import type { RuntimeExceptionOptions } from '@concepta/nestjs-core';
+import { HttpStatus } from '@nestjs/common';
+import { RepositoryQueryException } from '@concepta/nestjs-repository';
+
+/**
+ * Thrown when a write precondition is malformed (e.g. both `exists` and
+ * `lastUpdateTime` set) or unsupported on the requested operation.
+ */
+export class FirestoreInvalidPreconditionException extends RepositoryQueryException {
+  constructor(message: string, options?: RuntimeExceptionOptions) {
+    super('firestore-write', {
+      message,
+      messageParams: [],
+      httpStatus: HttpStatus.BAD_REQUEST,
+      ...options,
+    });
+    this.errorCode = 'FIRESTORE_INVALID_PRECONDITION';
+  }
+}

--- a/packages/rockets-repository-firestore/src/exceptions/firestore-precondition-failed.exception.ts
+++ b/packages/rockets-repository-firestore/src/exceptions/firestore-precondition-failed.exception.ts
@@ -1,0 +1,22 @@
+import type { RuntimeExceptionOptions } from '@concepta/nestjs-core';
+import { HttpStatus } from '@nestjs/common';
+import { RepositoryQueryException } from '@concepta/nestjs-repository';
+
+/**
+ * Thrown when a write precondition fails (wrong `lastUpdateTime` / exists).
+ */
+export class FirestorePreconditionFailedException extends RepositoryQueryException {
+  constructor(
+    collection: string,
+    documentId: string,
+    options?: RuntimeExceptionOptions,
+  ) {
+    super(collection, {
+      message: `Firestore precondition failed for "${collection}/${documentId}".`,
+      messageParams: [],
+      httpStatus: HttpStatus.PRECONDITION_FAILED,
+      ...options,
+    });
+    this.errorCode = 'FIRESTORE_PRECONDITION_FAILED';
+  }
+}

--- a/packages/rockets-repository-firestore/src/exceptions/firestore-transaction-aborted.exception.ts
+++ b/packages/rockets-repository-firestore/src/exceptions/firestore-transaction-aborted.exception.ts
@@ -1,0 +1,21 @@
+import type { RuntimeExceptionOptions } from '@concepta/nestjs-core';
+import { RepositoryQueryException } from '@concepta/nestjs-repository';
+
+/**
+ * Signals that the imperative Firestore transaction bridge aborted without
+ * committing. Swallowed by {@link FirestoreTransaction.rollback}; any other
+ * error from the underlying `runTransaction` is rethrown.
+ *
+ * Extends {@link RepositoryQueryException} so the repository hook permeator
+ * rethrows it untouched instead of wrapping it into a generic 500.
+ */
+export class FirestoreTransactionAbortedException extends RepositoryQueryException {
+  constructor(options?: RuntimeExceptionOptions) {
+    super('firestore-transaction', {
+      message: 'Firestore transaction aborted',
+      messageParams: [],
+      ...options,
+    });
+    this.errorCode = 'FIRESTORE_TRANSACTION_ABORTED';
+  }
+}

--- a/packages/rockets-repository-firestore/src/exceptions/firestore-transaction-backend-mismatch.exception.ts
+++ b/packages/rockets-repository-firestore/src/exceptions/firestore-transaction-backend-mismatch.exception.ts
@@ -1,0 +1,24 @@
+import type { RuntimeExceptionOptions } from '@concepta/nestjs-core';
+import { RepositoryQueryException } from '@concepta/nestjs-repository';
+
+/**
+ * Thrown when a Firestore transaction is opened for one backend while another
+ * backend's transaction is already ambient.
+ *
+ * A Firestore transaction belongs to a single database, so joining across
+ * backends would give false atomicity: part of the unit would commit outside
+ * the transaction.
+ */
+export class FirestoreTransactionBackendMismatchException extends RepositoryQueryException {
+  constructor(
+    message = 'Firestore transaction already active for a different backend — a transaction cannot span backends',
+    options?: RuntimeExceptionOptions,
+  ) {
+    super('firestore-transaction', {
+      message,
+      messageParams: [],
+      ...options,
+    });
+    this.errorCode = 'FIRESTORE_TRANSACTION_BACKEND_MISMATCH';
+  }
+}

--- a/packages/rockets-repository-firestore/src/exceptions/firestore-transaction-read-after-write.exception.ts
+++ b/packages/rockets-repository-firestore/src/exceptions/firestore-transaction-read-after-write.exception.ts
@@ -1,0 +1,22 @@
+import type { RuntimeExceptionOptions } from '@concepta/nestjs-core';
+import { HttpStatus } from '@nestjs/common';
+import { RepositoryQueryException } from '@concepta/nestjs-repository';
+
+/**
+ * Thrown when a Firestore transaction performs a read after a write in the
+ * same attempt (SDK rule: all reads before all writes).
+ */
+export class FirestoreTransactionReadAfterWriteException extends RepositoryQueryException {
+  constructor(
+    message = 'Firestore transactions require all reads before all writes',
+    options?: RuntimeExceptionOptions,
+  ) {
+    super('firestore-transaction', {
+      message,
+      messageParams: [],
+      httpStatus: HttpStatus.BAD_REQUEST,
+      ...options,
+    });
+    this.errorCode = 'FIRESTORE_TRANSACTION_READ_AFTER_WRITE';
+  }
+}

--- a/packages/rockets-repository-firestore/src/exceptions/firestore-transaction-retry-unsupported.exception.ts
+++ b/packages/rockets-repository-firestore/src/exceptions/firestore-transaction-retry-unsupported.exception.ts
@@ -1,0 +1,24 @@
+import type { RuntimeExceptionOptions } from '@concepta/nestjs-core';
+import { RepositoryQueryException } from '@concepta/nestjs-repository';
+
+/**
+ * Thrown when Firestore retries a contended transaction attempt while the
+ * imperative {@link FirestoreTransaction} bridge is in use.
+ *
+ * The bridge cannot re-execute application logic on retry; committing the
+ * empty retry batch would silently drop writes. Prefer
+ * `FirestoreBackend.runTransaction` for contended read-modify-write.
+ */
+export class FirestoreTransactionRetryUnsupportedException extends RepositoryQueryException {
+  constructor(
+    message = 'Firestore transaction retry is not supported by the imperative bridge — use backend.runTransaction() for contended read-modify-write',
+    options?: RuntimeExceptionOptions,
+  ) {
+    super('firestore-transaction', {
+      message,
+      messageParams: [],
+      ...options,
+    });
+    this.errorCode = 'FIRESTORE_TRANSACTION_RETRY_UNSUPPORTED';
+  }
+}

--- a/packages/rockets-repository-firestore/src/exceptions/firestore-transaction-write-limit-exceeded.exception.ts
+++ b/packages/rockets-repository-firestore/src/exceptions/firestore-transaction-write-limit-exceeded.exception.ts
@@ -1,0 +1,24 @@
+import type { RuntimeExceptionOptions } from '@concepta/nestjs-core';
+import { RepositoryQueryException } from '@concepta/nestjs-repository';
+
+import { FIRESTORE_MAX_TRANSACTION_WRITES } from '../constants/firestore-transaction.constants';
+
+/**
+ * Thrown when a transactional unit exceeds Firestore's write limit.
+ *
+ * The adapter does not split oversized units — callers must chunk or use
+ * {@link FirestoreBackend.writeBatch} for non-transactional bulk writes.
+ */
+export class FirestoreTransactionWriteLimitExceededException extends RepositoryQueryException {
+  constructor(
+    writeCount: number = FIRESTORE_MAX_TRANSACTION_WRITES + 1,
+    options?: RuntimeExceptionOptions,
+  ) {
+    super('firestore-transaction', {
+      message: `Firestore transaction write limit exceeded (${writeCount} > ${FIRESTORE_MAX_TRANSACTION_WRITES})`,
+      messageParams: [],
+      ...options,
+    });
+    this.errorCode = 'FIRESTORE_TRANSACTION_WRITE_LIMIT_EXCEEDED';
+  }
+}

--- a/packages/rockets-repository-firestore/src/index.ts
+++ b/packages/rockets-repository-firestore/src/index.ts
@@ -4,17 +4,26 @@ export {
   isFirestoreRepository,
 } from './repository/firestore-repository';
 export type { FirestoreProviderOptions } from './interfaces/firestore-provider-options.interface';
+export type { FirestoreBackend } from './interfaces/firestore-backend.interface';
+export type { FirestoreTransactionHandle } from './interfaces/firestore-transaction-handle.interface';
 export { FIRESTORE_REPOSITORY_MODULE_NAME } from './constants/firestore-repository.constants';
+export { FIRESTORE_DEFAULT_TRANSACTION_KEY } from './constants/firestore-transaction.constants';
 export {
   FIRESTORE_ALT_SOFT_DELETE_FIELD,
   FIRESTORE_DEFAULT_SOFT_DELETE_FIELD,
 } from './constants/firestore-soft-delete.constants';
 export { ensureFirebaseAdminApp } from './utils/ensure-firebase-admin-app';
 export { FirestoreDuplicateIdException } from './exceptions/firestore-duplicate-id.exception';
+export { FirestoreTransactionAbortedException } from './exceptions/firestore-transaction-aborted.exception';
+export { FirestoreTransactionRetryUnsupportedException } from './exceptions/firestore-transaction-retry-unsupported.exception';
 export { InMemoryFirestoreBackend } from './backends/in-memory-firestore.backend';
+export { AdminFirestoreBackend } from './backends/admin-firestore.backend';
 export { defineFirestoreRepository } from './integration/define-firestore-repository';
 export type { DefineFirestoreRepositoryOptions } from './integration/define-firestore-repository.config';
 export type {
   FirestoreRepositoryModuleOptions,
   FirestoreRepositoryRootOptions,
 } from './interfaces/firestore-repository-module-options.interface';
+export { FirestoreTransaction } from './transaction/firestore-transaction';
+export { FirestoreTransactionFactory } from './transaction/firestore-transaction.factory';
+export { runInFirestoreTransaction } from './transaction/run-in-firestore-transaction';

--- a/packages/rockets-repository-firestore/src/index.ts
+++ b/packages/rockets-repository-firestore/src/index.ts
@@ -20,6 +20,7 @@ export { backfillSoftDeleteNull } from './utils/backfill-soft-delete-null';
 export type { BackfillSoftDeleteNullOptions } from './utils/backfill-soft-delete-null';
 export { FirestoreDuplicateIdException } from './exceptions/firestore-duplicate-id.exception';
 export { FirestoreTransactionAbortedException } from './exceptions/firestore-transaction-aborted.exception';
+export { FirestoreTransactionBackendMismatchException } from './exceptions/firestore-transaction-backend-mismatch.exception';
 export { FirestoreTransactionRetryUnsupportedException } from './exceptions/firestore-transaction-retry-unsupported.exception';
 export { InMemoryFirestoreBackend } from './backends/in-memory-firestore.backend';
 export { AdminFirestoreBackend } from './backends/admin-firestore.backend';

--- a/packages/rockets-repository-firestore/src/index.ts
+++ b/packages/rockets-repository-firestore/src/index.ts
@@ -4,13 +4,28 @@ export {
   isFirestoreRepository,
 } from './repository/firestore-repository';
 export type { FirestoreProviderOptions } from './interfaces/firestore-provider-options.interface';
-export type { FirestoreBackend } from './interfaces/firestore-backend.interface';
+export type {
+  FirestoreBackend,
+  FirestoreBatchOperation,
+} from './interfaces/firestore-backend.interface';
 export type { FirestoreTransactionHandle } from './interfaces/firestore-transaction-handle.interface';
+export type {
+  FirestoreIncrementSentinel,
+  FirestoreWritePrecondition,
+} from './interfaces/firestore-write.interface';
+export {
+  firestoreIncrement,
+  isFirestoreIncrementSentinel,
+} from './interfaces/firestore-write.interface';
 export {
   FIRESTORE_BACKEND,
   FIRESTORE_REPOSITORY_MODULE_NAME,
 } from './constants/firestore-repository.constants';
-export { FIRESTORE_DEFAULT_TRANSACTION_KEY } from './constants/firestore-transaction.constants';
+export {
+  FIRESTORE_DEFAULT_TRANSACTION_KEY,
+  FIRESTORE_MAX_BATCH_WRITES,
+  FIRESTORE_MAX_TRANSACTION_WRITES,
+} from './constants/firestore-transaction.constants';
 export {
   FIRESTORE_ALT_SOFT_DELETE_FIELD,
   FIRESTORE_DEFAULT_SOFT_DELETE_FIELD,
@@ -18,10 +33,14 @@ export {
 export { ensureFirebaseAdminApp } from './utils/ensure-firebase-admin-app';
 export { backfillSoftDeleteNull } from './utils/backfill-soft-delete-null';
 export type { BackfillSoftDeleteNullOptions } from './utils/backfill-soft-delete-null';
+export { adminStreamBackfillSoftDeleteNull } from './utils/admin-stream-backfill-soft-delete-null';
+export type { AdminStreamBackfillSoftDeleteNullOptions } from './utils/admin-stream-backfill-soft-delete-null';
 export { FirestoreDuplicateIdException } from './exceptions/firestore-duplicate-id.exception';
+export { FirestorePreconditionFailedException } from './exceptions/firestore-precondition-failed.exception';
 export { FirestoreTransactionAbortedException } from './exceptions/firestore-transaction-aborted.exception';
 export { FirestoreTransactionBackendMismatchException } from './exceptions/firestore-transaction-backend-mismatch.exception';
 export { FirestoreTransactionRetryUnsupportedException } from './exceptions/firestore-transaction-retry-unsupported.exception';
+export { FirestoreTransactionWriteLimitExceededException } from './exceptions/firestore-transaction-write-limit-exceeded.exception';
 export { InMemoryFirestoreBackend } from './backends/in-memory-firestore.backend';
 export { AdminFirestoreBackend } from './backends/admin-firestore.backend';
 export { defineFirestoreRepository } from './integration/define-firestore-repository';

--- a/packages/rockets-repository-firestore/src/index.ts
+++ b/packages/rockets-repository-firestore/src/index.ts
@@ -3,6 +3,7 @@ export {
   FirestoreRepository,
   isFirestoreRepository,
 } from './repository/firestore-repository';
+export type { FirestoreRepositoryUpdateOptions } from './repository/firestore-repository';
 export type { FirestoreProviderOptions } from './interfaces/firestore-provider-options.interface';
 export type {
   FirestoreBackend,
@@ -37,10 +38,14 @@ export { adminStreamBackfillSoftDeleteNull } from './utils/admin-stream-backfill
 export type { AdminStreamBackfillSoftDeleteNullOptions } from './utils/admin-stream-backfill-soft-delete-null';
 export { FirestoreDuplicateIdException } from './exceptions/firestore-duplicate-id.exception';
 export { FirestorePreconditionFailedException } from './exceptions/firestore-precondition-failed.exception';
+export { FirestoreInvalidPreconditionException } from './exceptions/firestore-invalid-precondition.exception';
+export { FirestoreInvalidDocumentIdException } from './exceptions/firestore-invalid-document-id.exception';
+export { FirestoreBatchWriteLimitExceededException } from './exceptions/firestore-batch-write-limit-exceeded.exception';
 export { FirestoreTransactionAbortedException } from './exceptions/firestore-transaction-aborted.exception';
 export { FirestoreTransactionBackendMismatchException } from './exceptions/firestore-transaction-backend-mismatch.exception';
 export { FirestoreTransactionRetryUnsupportedException } from './exceptions/firestore-transaction-retry-unsupported.exception';
 export { FirestoreTransactionWriteLimitExceededException } from './exceptions/firestore-transaction-write-limit-exceeded.exception';
+export { FirestoreTransactionReadAfterWriteException } from './exceptions/firestore-transaction-read-after-write.exception';
 export { InMemoryFirestoreBackend } from './backends/in-memory-firestore.backend';
 export { AdminFirestoreBackend } from './backends/admin-firestore.backend';
 export { defineFirestoreRepository } from './integration/define-firestore-repository';

--- a/packages/rockets-repository-firestore/src/index.ts
+++ b/packages/rockets-repository-firestore/src/index.ts
@@ -6,13 +6,18 @@ export {
 export type { FirestoreProviderOptions } from './interfaces/firestore-provider-options.interface';
 export type { FirestoreBackend } from './interfaces/firestore-backend.interface';
 export type { FirestoreTransactionHandle } from './interfaces/firestore-transaction-handle.interface';
-export { FIRESTORE_REPOSITORY_MODULE_NAME } from './constants/firestore-repository.constants';
+export {
+  FIRESTORE_BACKEND,
+  FIRESTORE_REPOSITORY_MODULE_NAME,
+} from './constants/firestore-repository.constants';
 export { FIRESTORE_DEFAULT_TRANSACTION_KEY } from './constants/firestore-transaction.constants';
 export {
   FIRESTORE_ALT_SOFT_DELETE_FIELD,
   FIRESTORE_DEFAULT_SOFT_DELETE_FIELD,
 } from './constants/firestore-soft-delete.constants';
 export { ensureFirebaseAdminApp } from './utils/ensure-firebase-admin-app';
+export { backfillSoftDeleteNull } from './utils/backfill-soft-delete-null';
+export type { BackfillSoftDeleteNullOptions } from './utils/backfill-soft-delete-null';
 export { FirestoreDuplicateIdException } from './exceptions/firestore-duplicate-id.exception';
 export { FirestoreTransactionAbortedException } from './exceptions/firestore-transaction-aborted.exception';
 export { FirestoreTransactionRetryUnsupportedException } from './exceptions/firestore-transaction-retry-unsupported.exception';

--- a/packages/rockets-repository-firestore/src/interfaces/firestore-backend.interface.ts
+++ b/packages/rockets-repository-firestore/src/interfaces/firestore-backend.interface.ts
@@ -47,6 +47,7 @@ export interface FirestoreBackend {
     collection: string,
     documentId: string,
     data: Record<string, unknown>,
+    options?: { readonly skipExistenceRead?: boolean },
   ): Promise<void>;
   set(
     collection: string,

--- a/packages/rockets-repository-firestore/src/interfaces/firestore-backend.interface.ts
+++ b/packages/rockets-repository-firestore/src/interfaces/firestore-backend.interface.ts
@@ -3,6 +3,7 @@ import type {
   FirestoreQueryBranch,
 } from './firestore-query.interface';
 import type { FirestoreTransactionHandle } from './firestore-transaction-handle.interface';
+import type { FirestoreWritePrecondition } from './firestore-write.interface';
 
 /** @deprecated Use {@link FirestoreQueryFilter} via {@link FirestoreQueryBranch}. */
 export interface FirestoreEqualityFilter {
@@ -16,6 +17,19 @@ export interface FirestoreBranchQueryOptions {
   readonly skip?: number;
   readonly take?: number;
 }
+
+export type FirestoreBatchOperation =
+  | {
+      readonly op: 'create';
+      readonly collection: string;
+      readonly id: string;
+      readonly data: Record<string, unknown>;
+    }
+  | {
+      readonly op: 'delete';
+      readonly collection: string;
+      readonly id: string;
+    };
 
 export interface FirestoreBackend {
   get(
@@ -39,8 +53,13 @@ export interface FirestoreBackend {
     documentId: string,
     data: Record<string, unknown>,
     merge?: boolean,
+    precondition?: FirestoreWritePrecondition,
   ): Promise<void>;
-  delete(collection: string, documentId: string): Promise<void>;
+  delete(
+    collection: string,
+    documentId: string,
+    precondition?: FirestoreWritePrecondition,
+  ): Promise<void>;
   queryBranch(
     collection: string,
     options: FirestoreBranchQueryOptions,
@@ -59,4 +78,13 @@ export interface FirestoreBackend {
   runTransaction<T>(
     fn: (tx: FirestoreTransactionHandle) => Promise<T>,
   ): Promise<T>;
+  /**
+   * Atomic multi-write (Admin WriteBatch). Max 500 ops per call; chunk
+   * larger units yourself. Not available inside a transaction — use the
+   * ambient handle sequentially instead.
+   *
+   * @throws FirestoreDuplicateIdException when any create targets an
+   * existing id (whole batch rolls back).
+   */
+  writeBatch(operations: readonly FirestoreBatchOperation[]): Promise<void>;
 }

--- a/packages/rockets-repository-firestore/src/interfaces/firestore-backend.interface.ts
+++ b/packages/rockets-repository-firestore/src/interfaces/firestore-backend.interface.ts
@@ -2,6 +2,7 @@ import type {
   FirestoreOrderBy,
   FirestoreQueryBranch,
 } from './firestore-query.interface';
+import type { FirestoreTransactionHandle } from './firestore-transaction-handle.interface';
 
 /** @deprecated Use {@link FirestoreQueryFilter} via {@link FirestoreQueryBranch}. */
 export interface FirestoreEqualityFilter {
@@ -48,4 +49,14 @@ export interface FirestoreBackend {
     collection: string,
     branch: FirestoreQueryBranch,
   ): Promise<number>;
+  /**
+   * Run `fn` inside a single atomic unit. Admin backends map this to
+   * `Firestore.runTransaction`; the in-memory backend uses a copy-on-write
+   * snapshot. Prefer this callback form for contended read-modify-write —
+   * the imperative `TransactionInterface` bridge cannot re-run the handler
+   * body when Firestore retries an attempt.
+   */
+  runTransaction<T>(
+    fn: (tx: FirestoreTransactionHandle) => Promise<T>,
+  ): Promise<T>;
 }

--- a/packages/rockets-repository-firestore/src/interfaces/firestore-provider-options.interface.ts
+++ b/packages/rockets-repository-firestore/src/interfaces/firestore-provider-options.interface.ts
@@ -11,4 +11,16 @@ export interface FirestoreProviderOptions<
    * `deletedAt`; set explicitly when the class shape is not detectable).
    */
   readonly softDeleteField?: string;
+  /**
+   * Tier-1 uniqueness: derive the document id from this field on create when
+   * `id` is omitted. Composite unique constraints are not supported yet —
+   * declare them and the factory throws at boot.
+   */
+  readonly uniqueDocumentIdField?: string;
+  /**
+   * Declared unique constraints (from schema / registration). Composite
+   * entries (length \> 1) refuse at boot until the uniqueness-index collection
+   * lands (issue #44 P1-3 tier 2).
+   */
+  readonly uniqueConstraints?: ReadonlyArray<ReadonlyArray<string>>;
 }

--- a/packages/rockets-repository-firestore/src/interfaces/firestore-query.interface.ts
+++ b/packages/rockets-repository-firestore/src/interfaces/firestore-query.interface.ts
@@ -57,8 +57,7 @@ export type FirestorePostFilter =
       readonly field: string;
       readonly min: unknown;
       readonly max: unknown;
-    }
-  | { readonly kind: 'soft_delete_excluded'; readonly field: string };
+    };
 
 /** One conjunctive branch (AND of conditions) — OR becomes multiple branches. */
 export interface FirestoreQueryBranch {

--- a/packages/rockets-repository-firestore/src/interfaces/firestore-transaction-handle.interface.ts
+++ b/packages/rockets-repository-firestore/src/interfaces/firestore-transaction-handle.interface.ts
@@ -22,6 +22,7 @@ export interface FirestoreTransactionHandle {
     collection: string,
     documentId: string,
     data: Record<string, unknown>,
+    options?: { readonly skipExistenceRead?: boolean },
   ): Promise<void>;
   set(
     collection: string,

--- a/packages/rockets-repository-firestore/src/interfaces/firestore-transaction-handle.interface.ts
+++ b/packages/rockets-repository-firestore/src/interfaces/firestore-transaction-handle.interface.ts
@@ -1,0 +1,39 @@
+import type { FirestoreBranchQueryOptions } from './firestore-backend.interface';
+import type { FirestoreQueryBranch } from './firestore-query.interface';
+
+/**
+ * Mutable view of a single Firestore transaction attempt.
+ *
+ * Obtained from {@link FirestoreBackend.runTransaction} or from
+ * `TransactionInterface.getClient()` when the ambient Rockets transaction
+ * was started by this adapter's factory.
+ *
+ * Firestore requires all reads before all writes inside one attempt and may
+ * retry the whole attempt under contention — keep handlers idempotent.
+ */
+export interface FirestoreTransactionHandle {
+  get(
+    collection: string,
+    documentId: string,
+  ): Promise<Record<string, unknown> | null>;
+  create(
+    collection: string,
+    documentId: string,
+    data: Record<string, unknown>,
+  ): Promise<void>;
+  set(
+    collection: string,
+    documentId: string,
+    data: Record<string, unknown>,
+    merge?: boolean,
+  ): Promise<void>;
+  delete(collection: string, documentId: string): Promise<void>;
+  queryBranch(
+    collection: string,
+    options: FirestoreBranchQueryOptions,
+  ): Promise<Record<string, unknown>[]>;
+  countBranch(
+    collection: string,
+    branch: FirestoreQueryBranch,
+  ): Promise<number>;
+}

--- a/packages/rockets-repository-firestore/src/interfaces/firestore-transaction-handle.interface.ts
+++ b/packages/rockets-repository-firestore/src/interfaces/firestore-transaction-handle.interface.ts
@@ -1,5 +1,6 @@
 import type { FirestoreBranchQueryOptions } from './firestore-backend.interface';
 import type { FirestoreQueryBranch } from './firestore-query.interface';
+import type { FirestoreWritePrecondition } from './firestore-write.interface';
 
 /**
  * Mutable view of a single Firestore transaction attempt.
@@ -10,6 +11,7 @@ import type { FirestoreQueryBranch } from './firestore-query.interface';
  *
  * Firestore requires all reads before all writes inside one attempt and may
  * retry the whole attempt under contention — keep handlers idempotent.
+ * Write count is capped at {@link FIRESTORE_MAX_TRANSACTION_WRITES}.
  */
 export interface FirestoreTransactionHandle {
   get(
@@ -26,8 +28,13 @@ export interface FirestoreTransactionHandle {
     documentId: string,
     data: Record<string, unknown>,
     merge?: boolean,
+    precondition?: FirestoreWritePrecondition,
   ): Promise<void>;
-  delete(collection: string, documentId: string): Promise<void>;
+  delete(
+    collection: string,
+    documentId: string,
+    precondition?: FirestoreWritePrecondition,
+  ): Promise<void>;
   queryBranch(
     collection: string,
     options: FirestoreBranchQueryOptions,

--- a/packages/rockets-repository-firestore/src/interfaces/firestore-write.interface.ts
+++ b/packages/rockets-repository-firestore/src/interfaces/firestore-write.interface.ts
@@ -1,0 +1,36 @@
+/**
+ * Sentinel for Admin `FieldValue.increment(delta)`.
+ *
+ * Pass through repository patches / backend `set` data; Admin serialises to
+ * the native FieldValue, InMemory applies the delta numerically.
+ */
+export type FirestoreIncrementSentinel = {
+  readonly __firestoreIncrement: number;
+};
+
+export function firestoreIncrement(delta: number): FirestoreIncrementSentinel {
+  return { __firestoreIncrement: delta };
+}
+
+export function isFirestoreIncrementSentinel(
+  value: unknown,
+): value is FirestoreIncrementSentinel {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    '__firestoreIncrement' in value &&
+    typeof (value as FirestoreIncrementSentinel).__firestoreIncrement ===
+      'number'
+  );
+}
+
+/**
+ * Optional write precondition (Admin `Precondition`).
+ *
+ * Prefer transactions for contended leases; this is the non-transactional
+ * CAS path for heartbeats and simple counters.
+ */
+export interface FirestoreWritePrecondition {
+  readonly lastUpdateTime?: Date;
+  readonly exists?: boolean;
+}

--- a/packages/rockets-repository-firestore/src/repository/firestore-order-by-reconcile.ts
+++ b/packages/rockets-repository-firestore/src/repository/firestore-order-by-reconcile.ts
@@ -1,0 +1,70 @@
+import type {
+  FirestoreOrderBy,
+  FirestoreQueryBranch,
+  FirestoreFilterOp,
+} from '../interfaces/firestore-query.interface';
+
+const INEQUALITY_OPS: ReadonlySet<FirestoreFilterOp> = new Set([
+  '!=',
+  '<',
+  '<=',
+  '>',
+  '>=',
+]);
+
+export interface ReconciledOrderBy {
+  readonly serverOrderBy: readonly FirestoreOrderBy[] | undefined;
+  /**
+   * True when the server order differs from the caller's requested order —
+   * skip/take must not be pushed to the server (pagination would be wrong).
+   */
+  readonly clientReorder: boolean;
+}
+
+/**
+ * Firestore requires the first orderBy to be the inequality / range field.
+ * Prepend or promote that field; flag when local re-sort is required.
+ */
+export function reconcileOrderByWithInequality(
+  branch: FirestoreQueryBranch,
+  orderBy: readonly FirestoreOrderBy[] | undefined,
+): ReconciledOrderBy {
+  const inequalityField = findInequalityField(branch);
+  if (inequalityField === undefined) {
+    return { serverOrderBy: orderBy, clientReorder: false };
+  }
+
+  const requested = orderBy ?? [];
+  if (requested.length === 0) {
+    return {
+      serverOrderBy: [{ field: inequalityField, direction: 'asc' }],
+      clientReorder: false,
+    };
+  }
+
+  const first = requested[0];
+  if (first !== undefined && first.field === inequalityField) {
+    return { serverOrderBy: requested, clientReorder: false };
+  }
+
+  const withoutDup = requested.filter(
+    (clause) => clause.field !== inequalityField,
+  );
+  const promoted: FirestoreOrderBy = {
+    field: inequalityField,
+    direction: 'asc',
+  };
+  return {
+    serverOrderBy: [promoted, ...withoutDup],
+    clientReorder: true,
+  };
+}
+
+function findInequalityField(branch: FirestoreQueryBranch): string | undefined {
+  for (const filter of branch.filters) {
+    if (INEQUALITY_OPS.has(filter.op)) {
+      return filter.field;
+    }
+  }
+  return undefined;
+}

--- a/packages/rockets-repository-firestore/src/repository/firestore-order-by-reconcile.ts
+++ b/packages/rockets-repository-firestore/src/repository/firestore-order-by-reconcile.ts
@@ -22,49 +22,70 @@ export interface ReconciledOrderBy {
 }
 
 /**
- * Firestore requires the first orderBy to be the inequality / range field.
- * Prepend or promote that field; flag when local re-sort is required.
+ * Firestore requires every inequality / range field to appear in orderBy,
+ * with those fields leading. Promote missing ones; flag when local re-sort
+ * is required.
  */
 export function reconcileOrderByWithInequality(
   branch: FirestoreQueryBranch,
   orderBy: readonly FirestoreOrderBy[] | undefined,
 ): ReconciledOrderBy {
-  const inequalityField = findInequalityField(branch);
-  if (inequalityField === undefined) {
+  const inequalityFields = findInequalityFields(branch);
+  if (inequalityFields.length === 0) {
     return { serverOrderBy: orderBy, clientReorder: false };
   }
 
   const requested = orderBy ?? [];
   if (requested.length === 0) {
     return {
-      serverOrderBy: [{ field: inequalityField, direction: 'asc' }],
+      serverOrderBy: inequalityFields.map((field) => ({
+        field,
+        direction: 'asc' as const,
+      })),
       clientReorder: false,
     };
   }
 
-  const first = requested[0];
-  if (first !== undefined && first.field === inequalityField) {
+  // Firestore only requires inequality fields to lead; their relative order
+  // among themselves is free. Keep the caller's order when the leading set
+  // matches so limit() pushdown stays available.
+  const leading = requested
+    .slice(0, inequalityFields.length)
+    .map((clause) => clause.field);
+  const inequalitySet = new Set(inequalityFields);
+  const leadingMatch =
+    leading.length === inequalityFields.length &&
+    leading.every((field) => inequalitySet.has(field)) &&
+    inequalityFields.every((field) => leading.includes(field));
+  if (leadingMatch) {
     return { serverOrderBy: requested, clientReorder: false };
   }
 
-  const withoutDup = requested.filter(
-    (clause) => clause.field !== inequalityField,
+  const remainder = requested.filter(
+    (clause) => !inequalitySet.has(clause.field),
   );
-  const promoted: FirestoreOrderBy = {
-    field: inequalityField,
-    direction: 'asc',
-  };
+  const promoted: FirestoreOrderBy[] = inequalityFields.map((field) => {
+    const existing = requested.find((clause) => clause.field === field);
+    return {
+      field,
+      direction: existing?.direction ?? 'asc',
+    };
+  });
+
   return {
-    serverOrderBy: [promoted, ...withoutDup],
+    serverOrderBy: [...promoted, ...remainder],
     clientReorder: true,
   };
 }
 
-function findInequalityField(branch: FirestoreQueryBranch): string | undefined {
+function findInequalityFields(branch: FirestoreQueryBranch): string[] {
+  const fields: string[] = [];
+  const seen = new Set<string>();
   for (const filter of branch.filters) {
-    if (INEQUALITY_OPS.has(filter.op)) {
-      return filter.field;
+    if (INEQUALITY_OPS.has(filter.op) && !seen.has(filter.field)) {
+      seen.add(filter.field);
+      fields.push(filter.field);
     }
   }
-  return undefined;
+  return fields;
 }

--- a/packages/rockets-repository-firestore/src/repository/firestore-post-filter.ts
+++ b/packages/rockets-repository-firestore/src/repository/firestore-post-filter.ts
@@ -49,8 +49,6 @@ function matchesPostFilter(
       );
     case 'between':
       return compareBetween(value, filter.min, filter.max);
-    case 'soft_delete_excluded':
-      return value === null || value === undefined;
     default: {
       const _exhaustive: never = filter;
       return _exhaustive;

--- a/packages/rockets-repository-firestore/src/repository/firestore-query-runner.ts
+++ b/packages/rockets-repository-firestore/src/repository/firestore-query-runner.ts
@@ -6,8 +6,13 @@ import type {
 } from '../interfaces/firestore-query.interface';
 import { sortFirestoreRows } from './firestore-sort';
 
+type FirestoreQueryClient = Pick<
+  FirestoreBackend,
+  'queryBranch' | 'countBranch'
+>;
+
 export async function runFirestoreQuery(
-  backend: FirestoreBackend,
+  backend: FirestoreQueryClient,
   collection: string,
   request: FirestoreQueryRequest,
 ): Promise<Record<string, unknown>[]> {
@@ -56,7 +61,7 @@ export async function runFirestoreQuery(
 }
 
 export async function runFirestoreCount(
-  backend: FirestoreBackend,
+  backend: FirestoreQueryClient,
   collection: string,
   request: Omit<FirestoreQueryRequest, 'orderBy' | 'skip' | 'take'>,
 ): Promise<number> {

--- a/packages/rockets-repository-firestore/src/repository/firestore-query-runner.ts
+++ b/packages/rockets-repository-firestore/src/repository/firestore-query-runner.ts
@@ -4,6 +4,7 @@ import type {
   FirestoreQueryFilter,
   FirestoreQueryRequest,
 } from '../interfaces/firestore-query.interface';
+import { reconcileOrderByWithInequality } from './firestore-order-by-reconcile';
 import { sortFirestoreRows } from './firestore-sort';
 
 type FirestoreQueryClient = Pick<
@@ -24,15 +25,26 @@ export async function runFirestoreQuery(
 
   const merged = new Map<string, Record<string, unknown>>();
 
-  const pushToServer =
+  const singleBranch =
     branches.length === 1 &&
     branches[0] !== undefined &&
     branches[0].postFilters.length === 0;
 
+  const reconciled = singleBranch
+    ? reconcileOrderByWithInequality(branches[0], request.orderBy)
+    : undefined;
+
+  const pushToServer =
+    singleBranch && reconciled !== undefined && !reconciled.clientReorder;
+
   for (const branch of branches) {
+    const branchReconciled = reconcileOrderByWithInequality(
+      branch,
+      request.orderBy,
+    );
     const rows = await backend.queryBranch(collection, {
       branch,
-      orderBy: pushToServer ? request.orderBy : undefined,
+      orderBy: pushToServer ? branchReconciled.serverOrderBy : request.orderBy,
       skip: pushToServer ? request.skip : undefined,
       take: pushToServer ? request.take : undefined,
     });

--- a/packages/rockets-repository-firestore/src/repository/firestore-query-runner.ts
+++ b/packages/rockets-repository-firestore/src/repository/firestore-query-runner.ts
@@ -1,7 +1,7 @@
 import type { FirestoreBackend } from '../interfaces/firestore-backend.interface';
 import type {
-  FirestorePostFilter,
   FirestoreQueryBranch,
+  FirestoreQueryFilter,
   FirestoreQueryRequest,
 } from '../interfaces/firestore-query.interface';
 import { sortFirestoreRows } from './firestore-sort';
@@ -88,6 +88,12 @@ export async function runFirestoreCount(
   return rows.length;
 }
 
+/**
+ * Soft-delete exclusion is a server filter (`field == null`), not a
+ * post-filter. That keeps `pushToServer` true so `limit()` / `count()` stay
+ * on the backend. Callers must materialize explicit `null` on live docs —
+ * Firestore equality does not match missing fields.
+ */
 function augmentBranchesForSoftDelete(
   branches: readonly FirestoreQueryBranch[],
   softDeleteField: string | undefined,
@@ -97,14 +103,15 @@ function augmentBranchesForSoftDelete(
     return [...branches];
   }
 
-  const exclusion: FirestorePostFilter = {
-    kind: 'soft_delete_excluded',
+  const liveFilter: FirestoreQueryFilter = {
     field: softDeleteField,
+    op: '==',
+    value: null,
   };
 
   return branches.map((branch) => ({
     ...branch,
-    postFilters: [...branch.postFilters, exclusion],
+    filters: [...branch.filters, liveFilter],
   }));
 }
 

--- a/packages/rockets-repository-firestore/src/repository/firestore-repository.ts
+++ b/packages/rockets-repository-firestore/src/repository/firestore-repository.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from 'crypto';
-import type { DeepPartial } from '@concepta/nestjs-core';
+import { AppContextHost, type DeepPartial } from '@concepta/nestjs-core';
 import {
   isWhereCondition,
   RepositoryAdapter,
   SortOrder,
+  TrxCtx,
   type RepositoryCreateOptions,
   type RepositoryDeleteOptions,
   type RepositoryFindOneOptions,
@@ -20,39 +21,52 @@ import {
   FIRESTORE_ALT_SOFT_DELETE_FIELD,
   FIRESTORE_DEFAULT_SOFT_DELETE_FIELD,
 } from '../constants/firestore-soft-delete.constants';
+import { FIRESTORE_DEFAULT_TRANSACTION_KEY } from '../constants/firestore-transaction.constants';
 import type { FirestoreBackend } from '../interfaces/firestore-backend.interface';
 import type {
   FirestoreOrderBy,
   FirestoreQueryRequest,
 } from '../interfaces/firestore-query.interface';
+import type { FirestoreTransactionHandle } from '../interfaces/firestore-transaction-handle.interface';
 import { resolveSoftDeleteFieldFromMetadata } from './firestore-entity-metadata';
 import { runFirestoreCount, runFirestoreQuery } from './firestore-query-runner';
 import { translateDnfBranch } from './firestore-where.translator';
+import { getAmbientFirestoreTransaction } from '../transaction/firestore-transaction-context';
 
 export interface FirestoreRepositoryOptions<Entity extends PlainLiteralObject> {
   readonly entityKey: string;
   readonly collection: string;
   readonly metadata: RepositoryMetadataInterface<Entity>;
   readonly backend: FirestoreBackend;
+  readonly transactionKey?: string;
 }
+
+type StoreClient = Pick<
+  FirestoreBackend,
+  'get' | 'create' | 'set' | 'delete' | 'queryBranch' | 'countBranch'
+>;
 
 export class FirestoreRepository<
   Entity extends PlainLiteralObject,
 > extends RepositoryAdapter<Entity> {
   readonly metadata: RepositoryMetadataInterface<Entity>;
   private readonly softDeleteField?: string;
+  private readonly transactionKey: string;
 
   constructor(private readonly options: FirestoreRepositoryOptions<Entity>) {
     super(options.entityKey);
     this.metadata = options.metadata;
     this.softDeleteField = resolveSoftDeleteFieldFromMetadata(options.metadata);
+    this.transactionKey =
+      options.transactionKey ?? FIRESTORE_DEFAULT_TRANSACTION_KEY;
   }
 
   protected async doFind(
     options?: RepositoryFindOptions<Entity>,
   ): Promise<Entity[]> {
+    const client = await this.resolveClient(options?.ctx);
     const rows = await runFirestoreQuery(
-      this.options.backend,
+      client,
       this.options.collection,
       this.buildQueryRequest(options),
     );
@@ -69,8 +83,9 @@ export class FirestoreRepository<
   protected async doCount(
     options?: RepositoryFindOptions<Entity>,
   ): Promise<number> {
+    const client = await this.resolveClient(options?.ctx);
     const request = this.buildQueryRequest(options);
-    return runFirestoreCount(this.options.backend, this.options.collection, {
+    return runFirestoreCount(client, this.options.collection, {
       branches: request.branches,
       withDeleted: request.withDeleted,
       softDeleteField: request.softDeleteField,
@@ -80,10 +95,11 @@ export class FirestoreRepository<
   protected async doFindAndCount(
     options?: RepositoryFindOptions<Entity>,
   ): Promise<[Entity[], number]> {
+    const client = await this.resolveClient(options?.ctx);
     const request = this.buildQueryRequest(options);
     const [rows, total] = await Promise.all([
-      runFirestoreQuery(this.options.backend, this.options.collection, request),
-      runFirestoreCount(this.options.backend, this.options.collection, {
+      runFirestoreQuery(client, this.options.collection, request),
+      runFirestoreCount(client, this.options.collection, {
         branches: request.branches,
         withDeleted: request.withDeleted,
         softDeleteField: request.softDeleteField,
@@ -94,11 +110,13 @@ export class FirestoreRepository<
 
   protected async doCreate(
     entity: DeepPartial<Entity>,
-    _options?: RepositoryCreateOptions,
+    options?: RepositoryCreateOptions,
   ): Promise<Entity> {
+    const client = await this.resolveClient(options?.ctx);
     const id = this.resolveId(entity);
     const stored = this.toStore({ ...entity, id } as DeepPartial<Entity>);
-    await this.options.backend.create(this.options.collection, id, stored);
+    await client.create(this.options.collection, id, stored);
+    this.markDirty(options?.ctx);
     return this.fromStore(stored);
   }
 
@@ -116,41 +134,49 @@ export class FirestoreRepository<
   protected async doUpdate(
     entity: Entity,
     data: DeepPartial<Entity>,
-    _options?: RepositoryUpdateOptions,
+    options?: RepositoryUpdateOptions,
   ): Promise<Entity> {
+    const client = await this.resolveClient(options?.ctx);
     const id = this.resolveId(entity);
     const merged = this.toStore({ ...entity, ...data, id });
-    await this.options.backend.set(this.options.collection, id, merged, true);
+    await client.set(this.options.collection, id, merged, true);
+    this.markDirty(options?.ctx);
     return this.fromStore(merged);
   }
 
   protected async doUpsert(
     entity: DeepPartial<Entity>,
-    _options?: RepositoryUpsertOptions,
+    options?: RepositoryUpsertOptions,
   ): Promise<Entity> {
+    const client = await this.resolveClient(options?.ctx);
     const id = this.resolveId(entity);
     const stored = this.toStore({ ...entity, id } as DeepPartial<Entity>);
-    await this.options.backend.set(this.options.collection, id, stored, true);
+    await client.set(this.options.collection, id, stored, true);
+    this.markDirty(options?.ctx);
     return this.fromStore(stored);
   }
 
   protected async doReplace(
     entity: Entity,
     data: DeepPartial<Entity>,
-    _options?: RepositoryUpdateOptions,
+    options?: RepositoryUpdateOptions,
   ): Promise<Entity> {
+    const client = await this.resolveClient(options?.ctx);
     const id = this.resolveId(entity);
     const stored = this.toStore({ ...data, id });
-    await this.options.backend.set(this.options.collection, id, stored, false);
+    await client.set(this.options.collection, id, stored, false);
+    this.markDirty(options?.ctx);
     return this.fromStore(stored);
   }
 
   protected async doDelete(
     entity: Entity,
-    _options?: RepositoryDeleteOptions,
+    options?: RepositoryDeleteOptions,
   ): Promise<Entity> {
+    const client = await this.resolveClient(options?.ctx);
     const id = this.resolveId(entity);
-    await this.options.backend.delete(this.options.collection, id);
+    await client.delete(this.options.collection, id);
+    this.markDirty(options?.ctx);
     return entity;
   }
 
@@ -166,26 +192,30 @@ export class FirestoreRepository<
 
   protected async doSoftDelete(
     entity: Entity,
-    _options?: RepositoryDeleteOptions,
+    options?: RepositoryDeleteOptions,
   ): Promise<Entity> {
     const field = this.requireSoftDeleteField();
+    const client = await this.resolveClient(options?.ctx);
     const id = this.resolveId(entity);
     const removedAt = new Date();
     const patch = { [field]: removedAt } as DeepPartial<Entity>;
     const merged = this.toStore({ ...entity, ...patch, id });
-    await this.options.backend.set(this.options.collection, id, merged, true);
+    await client.set(this.options.collection, id, merged, true);
+    this.markDirty(options?.ctx);
     return this.fromStore(merged);
   }
 
   protected async doRestore(
     entity: Entity,
-    _options?: RepositoryRestoreOptions,
+    options?: RepositoryRestoreOptions,
   ): Promise<Entity> {
     const field = this.requireSoftDeleteField();
+    const client = await this.resolveClient(options?.ctx);
     const id = this.resolveId(entity);
     const patch = { [field]: null } as DeepPartial<Entity>;
     const merged = this.toStore({ ...entity, ...patch, id });
-    await this.options.backend.set(this.options.collection, id, merged, true);
+    await client.set(this.options.collection, id, merged, true);
+    this.markDirty(options?.ctx);
     return this.fromStore(merged);
   }
 
@@ -198,6 +228,51 @@ export class FirestoreRepository<
     ...entityLikes: DeepPartial<Entity>[]
   ): Entity {
     return Object.assign(mergeIntoEntity, ...entityLikes);
+  }
+
+  private async resolveClient(ctx?: PlainLiteralObject): Promise<StoreClient> {
+    const handle = await this.resolveTransactionHandle(ctx);
+    return handle ?? this.options.backend;
+  }
+
+  private async resolveTransactionHandle(
+    ctx?: PlainLiteralObject,
+  ): Promise<FirestoreTransactionHandle | null> {
+    // Callback-scoped API (runInFirestoreTransaction) — preferred under contention.
+    const ambient = getAmbientFirestoreTransaction();
+    if (ambient !== undefined) {
+      return ambient;
+    }
+
+    // Imperative TransactionScope bridge — fail-closed on Firestore retry.
+    const context = AppContextHost.from(ctx);
+    if (!context.supports(TrxCtx)) {
+      return null;
+    }
+    const { trx } = context.with(TrxCtx);
+    if (!trx?.isSupported) {
+      return null;
+    }
+    const tx = await trx.getOrStart(this.transactionKey);
+    return tx.getClient<FirestoreTransactionHandle>();
+  }
+
+  private markDirty(ctx?: PlainLiteralObject): void {
+    // Ambient callback transactions commit when runTransaction returns —
+    // no dirty flag to track.
+    if (getAmbientFirestoreTransaction() !== undefined) {
+      return;
+    }
+    const context = AppContextHost.from(ctx);
+    if (!context.supports(TrxCtx)) {
+      return;
+    }
+    const { trx } = context.with(TrxCtx);
+    if (!trx?.isSupported) {
+      return;
+    }
+    const tx = trx.get(this.transactionKey);
+    tx?.markDirty();
   }
 
   private buildQueryRequest(

--- a/packages/rockets-repository-firestore/src/repository/firestore-repository.ts
+++ b/packages/rockets-repository-firestore/src/repository/firestore-repository.ts
@@ -165,7 +165,14 @@ export class FirestoreRepository<
   ): Promise<Entity> {
     const client = await this.resolveClient(options?.ctx);
     const id = this.resolveId(entity);
-    const stored = this.toStore({ ...entity, id } as DeepPartial<Entity>);
+    // An upsert that lands on a NEW document writes with `merge: true`, so
+    // without the marker the row has no soft-delete field at all and
+    // `field == null` never matches it — invisible to every default list.
+    // Materializing unconditionally would resurrect soft-deleted rows, so
+    // the state of the existing document decides.
+    const stored = this.toStore({ ...entity, id } as DeepPartial<Entity>, {
+      materializeSoftDeleteNull: await this.isMissingDocument(client, id),
+    });
     await client.set(this.options.collection, id, stored, true);
     this.markDirty(options?.ctx);
     return this.fromStore(stored);
@@ -178,7 +185,13 @@ export class FirestoreRepository<
   ): Promise<Entity> {
     const client = await this.resolveClient(options?.ctx);
     const id = this.resolveId(entity);
-    const stored = this.toStore({ ...data, id });
+    // Replace overwrites the whole document (`merge: false`). Carrying the
+    // soft-delete state from the loaded entity keeps a live row visible and
+    // a soft-deleted row deleted; the fallback covers entities built by hand.
+    const stored = this.toStore(
+      this.carrySoftDeleteField({ ...data, id }, entity),
+      { materializeSoftDeleteNull: true },
+    );
     await client.set(this.options.collection, id, stored, false);
     this.markDirty(options?.ctx);
     return this.fromStore(stored);
@@ -253,8 +266,11 @@ export class FirestoreRepository<
   private async resolveTransactionHandle(
     ctx?: PlainLiteralObject,
   ): Promise<FirestoreTransactionHandle | null> {
-    // Callback-scoped API (runInFirestoreTransaction) — preferred under contention.
-    const ambient = getAmbientFirestoreTransaction();
+    // Callback-scoped API (runInFirestoreTransaction) — preferred under
+    // contention. Only joined when the ambient transaction belongs to THIS
+    // repository's backend; a handle from another backend targets another
+    // database, so this repository writes through its own backend instead.
+    const ambient = getAmbientFirestoreTransaction(this.options.backend);
     if (ambient !== undefined) {
       return ambient;
     }
@@ -275,7 +291,7 @@ export class FirestoreRepository<
   private markDirty(ctx?: PlainLiteralObject): void {
     // Ambient callback transactions commit when runTransaction returns —
     // no dirty flag to track.
-    if (getAmbientFirestoreTransaction() !== undefined) {
+    if (getAmbientFirestoreTransaction(this.options.backend) !== undefined) {
       return;
     }
     const context = AppContextHost.from(ctx);
@@ -319,6 +335,42 @@ export class FirestoreRepository<
       );
     }
     return this.softDeleteField;
+  }
+
+  /**
+   * True when the soft-delete marker has to be invented for `id`. Skips the
+   * extra read when the entity is not soft-deletable or already carries the
+   * field.
+   */
+  private async isMissingDocument(
+    client: StoreClient,
+    id: string,
+  ): Promise<boolean> {
+    if (this.softDeleteField === undefined) {
+      return false;
+    }
+    const existing = await client.get(this.options.collection, id);
+    return existing === null;
+  }
+
+  private carrySoftDeleteField(
+    target: DeepPartial<Entity>,
+    source: Entity,
+  ): DeepPartial<Entity> {
+    const field = this.softDeleteField;
+    if (field === undefined) {
+      return target;
+    }
+    const next: Record<string, unknown> = { ...target };
+    if (field in next) {
+      return target;
+    }
+    const current: Record<string, unknown> = { ...source };
+    if (!(field in current)) {
+      return target;
+    }
+    next[field] = current[field];
+    return next as DeepPartial<Entity>;
   }
 
   private resolveId(entity: DeepPartial<Entity> | Entity): string {

--- a/packages/rockets-repository-firestore/src/repository/firestore-repository.ts
+++ b/packages/rockets-repository-firestore/src/repository/firestore-repository.ts
@@ -38,7 +38,10 @@ import { deriveFirestoreDocumentId } from '../utils/firestore-deterministic-id';
 import { resolveSoftDeleteFieldFromMetadata } from './firestore-entity-metadata';
 import { runFirestoreCount, runFirestoreQuery } from './firestore-query-runner';
 import { translateDnfBranch } from './firestore-where.translator';
-import { getAmbientFirestoreTransaction } from '../transaction/firestore-transaction-context';
+import {
+  getAmbientFirestoreTransaction,
+  getAmbientFirestoreTransactionOwner,
+} from '../transaction/firestore-transaction-context';
 import { runInFirestoreTransaction } from '../transaction/run-in-firestore-transaction';
 
 export interface FirestoreRepositoryOptions<Entity extends PlainLiteralObject> {
@@ -289,6 +292,29 @@ export class FirestoreRepository<
     entity: DeepPartial<Entity>,
     options?: RepositoryUpsertOptions,
   ): Promise<Entity> {
+    // The soft-delete decision below reads the document, then writes based on
+    // what it saw. Outside a transaction those two calls hit the raw backend
+    // non-atomically: a concurrent create+soft-delete landing between them
+    // would let this write's materialized `null` resurrect the row. Open our
+    // own transaction so the decision and the write are atomic (SDK retries
+    // re-execute on contention). Skipped when the entity already carries the
+    // soft-delete field (the write value is caller-supplied, not read-derived —
+    // no race) or there is no soft-delete field at all. Also skipped when any
+    // Firestore transaction is already ambient: a same-backend one already
+    // makes this atomic, and a foreign-backend one must keep writing through
+    // this repository's own backend (see the cross-backend test) rather than
+    // fail the span guard in runInFirestoreTransaction.
+    const softDeleteField = this.softDeleteField;
+    const needsSoftDeleteRead =
+      softDeleteField !== undefined &&
+      (entity as Record<string, unknown>)[softDeleteField] === undefined;
+    if (
+      needsSoftDeleteRead &&
+      getAmbientFirestoreTransactionOwner() === undefined &&
+      !(await this.isInTransaction(options?.ctx))
+    ) {
+      return this.transaction(() => this.doUpsert(entity, options));
+    }
     const client = await this.resolveClient(options?.ctx);
     const id = this.resolveId(entity);
     // An upsert that lands on a NEW document writes with `merge: true`, so
@@ -309,13 +335,30 @@ export class FirestoreRepository<
     data: DeepPartial<Entity>,
     options?: RepositoryUpdateOptions,
   ): Promise<Entity> {
-    const client = await this.resolveClient(options?.ctx);
     const id = this.resolveId(entity);
     // Replace overwrites the whole document (`merge: false`). Carry the
     // soft-delete state from the loaded entity when present; otherwise read
     // the live document so a hand-built `{ id }` entity cannot invent `null`
     // over a soft-deleted row.
     const payload = this.carrySoftDeleteField({ ...data, id }, entity);
+    // A read to decide materialization only happens when the payload still
+    // lacks the soft-delete field. When it does, open a transaction so a
+    // concurrent create+soft-delete cannot slip between the read and the write
+    // and get resurrected (see doUpsert, including the ambient-owner guard).
+    // The common carry path already has the field, reads nothing, and skips
+    // the transaction.
+    const softDeleteField = this.softDeleteField;
+    const needsSoftDeleteRead =
+      softDeleteField !== undefined &&
+      (payload as Record<string, unknown>)[softDeleteField] === undefined;
+    if (
+      needsSoftDeleteRead &&
+      getAmbientFirestoreTransactionOwner() === undefined &&
+      !(await this.isInTransaction(options?.ctx))
+    ) {
+      return this.transaction(() => this.doReplace(entity, data, options));
+    }
+    const client = await this.resolveClient(options?.ctx);
     const materializeSoftDeleteNull =
       await this.shouldMaterializeSoftDeleteOnReplace(client, id, payload);
 

--- a/packages/rockets-repository-firestore/src/repository/firestore-repository.ts
+++ b/packages/rockets-repository-firestore/src/repository/firestore-repository.ts
@@ -22,12 +22,18 @@ import {
   FIRESTORE_DEFAULT_SOFT_DELETE_FIELD,
 } from '../constants/firestore-soft-delete.constants';
 import { FIRESTORE_DEFAULT_TRANSACTION_KEY } from '../constants/firestore-transaction.constants';
+import { FIRESTORE_MAX_BATCH_WRITES } from '../constants/firestore-transaction.constants';
 import type { FirestoreBackend } from '../interfaces/firestore-backend.interface';
 import type {
   FirestoreOrderBy,
   FirestoreQueryRequest,
 } from '../interfaces/firestore-query.interface';
 import type { FirestoreTransactionHandle } from '../interfaces/firestore-transaction-handle.interface';
+import {
+  firestoreIncrement,
+  type FirestoreWritePrecondition,
+} from '../interfaces/firestore-write.interface';
+import { deriveFirestoreDocumentId } from '../utils/firestore-deterministic-id';
 import { resolveSoftDeleteFieldFromMetadata } from './firestore-entity-metadata';
 import { runFirestoreCount, runFirestoreQuery } from './firestore-query-runner';
 import { translateDnfBranch } from './firestore-where.translator';
@@ -40,6 +46,8 @@ export interface FirestoreRepositoryOptions<Entity extends PlainLiteralObject> {
   readonly metadata: RepositoryMetadataInterface<Entity>;
   readonly backend: FirestoreBackend;
   readonly transactionKey?: string;
+  /** Derive document id from this field when `id` is omitted on create. */
+  readonly uniqueDocumentIdField?: string;
 }
 
 type StoreClient = Pick<
@@ -72,6 +80,31 @@ export class FirestoreRepository<
    */
   async transaction<T>(fn: () => Promise<T>): Promise<T> {
     return runInFirestoreTransaction(this.options.backend, fn);
+  }
+
+  /**
+   * Atomic field increment without a full document read-modify-write.
+   * Prefer this for counters / heartbeats outside a transaction.
+   */
+  async increment(
+    entity: Entity,
+    field: keyof Entity & string,
+    delta: number,
+    options?: {
+      readonly ctx?: PlainLiteralObject;
+      readonly precondition?: FirestoreWritePrecondition;
+    },
+  ): Promise<void> {
+    const client = await this.resolveClient(options?.ctx);
+    const id = this.resolveId(entity);
+    await client.set(
+      this.options.collection,
+      id,
+      { [field]: firestoreIncrement(delta) },
+      true,
+      options?.precondition,
+    );
+    this.markDirty(options?.ctx);
   }
 
   protected async doFind(
@@ -139,11 +172,43 @@ export class FirestoreRepository<
     entities: DeepPartial<Entity>[],
     options?: RepositoryCreateOptions,
   ): Promise<Entity[]> {
-    const created: Entity[] = [];
-    for (const entity of entities) {
-      created.push(await this.doCreate(entity, options));
+    if (entities.length === 0) {
+      return [];
     }
-    return created;
+
+    if (await this.isInTransaction(options?.ctx)) {
+      const created: Entity[] = [];
+      for (const entity of entities) {
+        created.push(await this.doCreate(entity, options));
+      }
+      return created;
+    }
+
+    const prepared = entities.map((entity) => {
+      const id = this.resolveId(entity);
+      const stored = this.toStore({ ...entity, id } as DeepPartial<Entity>, {
+        materializeSoftDeleteNull: true,
+      });
+      return { id, stored };
+    });
+
+    for (
+      let offset = 0;
+      offset < prepared.length;
+      offset += FIRESTORE_MAX_BATCH_WRITES
+    ) {
+      const chunk = prepared.slice(offset, offset + FIRESTORE_MAX_BATCH_WRITES);
+      await this.options.backend.writeBatch(
+        chunk.map((row) => ({
+          op: 'create' as const,
+          collection: this.options.collection,
+          id: row.id,
+          data: row.stored,
+        })),
+      );
+    }
+
+    return prepared.map((row) => this.fromStore(row.stored));
   }
 
   protected async doUpdate(
@@ -212,8 +277,31 @@ export class FirestoreRepository<
     entities: Entity[],
     options?: RepositoryDeleteOptions,
   ): Promise<Entity[]> {
-    for (const entity of entities) {
-      await this.doDelete(entity, options);
+    if (entities.length === 0) {
+      return entities;
+    }
+
+    if (await this.isInTransaction(options?.ctx)) {
+      for (const entity of entities) {
+        await this.doDelete(entity, options);
+      }
+      return entities;
+    }
+
+    const ids = entities.map((entity) => this.resolveId(entity));
+    for (
+      let offset = 0;
+      offset < ids.length;
+      offset += FIRESTORE_MAX_BATCH_WRITES
+    ) {
+      const chunk = ids.slice(offset, offset + FIRESTORE_MAX_BATCH_WRITES);
+      await this.options.backend.writeBatch(
+        chunk.map((id) => ({
+          op: 'delete' as const,
+          collection: this.options.collection,
+          id,
+        })),
+      );
     }
     return entities;
   }
@@ -373,10 +461,19 @@ export class FirestoreRepository<
     return next as DeepPartial<Entity>;
   }
 
+  private async isInTransaction(ctx?: PlainLiteralObject): Promise<boolean> {
+    return (await this.resolveTransactionHandle(ctx)) !== null;
+  }
+
   private resolveId(entity: DeepPartial<Entity> | Entity): string {
     const candidate = (entity as { readonly id?: string }).id;
     if (typeof candidate === 'string' && candidate.length > 0) {
       return candidate;
+    }
+    const uniqueField = this.options.uniqueDocumentIdField;
+    if (uniqueField !== undefined) {
+      const record: Record<string, unknown> = { ...entity };
+      return deriveFirestoreDocumentId(record[uniqueField]);
     }
     return randomUUID();
   }

--- a/packages/rockets-repository-firestore/src/repository/firestore-repository.ts
+++ b/packages/rockets-repository-firestore/src/repository/firestore-repository.ts
@@ -32,6 +32,7 @@ import { resolveSoftDeleteFieldFromMetadata } from './firestore-entity-metadata'
 import { runFirestoreCount, runFirestoreQuery } from './firestore-query-runner';
 import { translateDnfBranch } from './firestore-where.translator';
 import { getAmbientFirestoreTransaction } from '../transaction/firestore-transaction-context';
+import { runInFirestoreTransaction } from '../transaction/run-in-firestore-transaction';
 
 export interface FirestoreRepositoryOptions<Entity extends PlainLiteralObject> {
   readonly entityKey: string;
@@ -59,6 +60,18 @@ export class FirestoreRepository<
     this.softDeleteField = resolveSoftDeleteFieldFromMetadata(options.metadata);
     this.transactionKey =
       options.transactionKey ?? FIRESTORE_DEFAULT_TRANSACTION_KEY;
+  }
+
+  /**
+   * Preferred transactional path for Firestore: `fn` runs inside the SDK
+   * callback so contention retries re-execute the body. Nested repository
+   * calls join via ambient ALS — no `{ ctx }` required.
+   *
+   * Do not use `TransactionScope` / `transactional: true` for contended
+   * read-modify-write; that bridge refuses Firestore retries.
+   */
+  async transaction<T>(fn: () => Promise<T>): Promise<T> {
+    return runInFirestoreTransaction(this.options.backend, fn);
   }
 
   protected async doFind(
@@ -114,7 +127,9 @@ export class FirestoreRepository<
   ): Promise<Entity> {
     const client = await this.resolveClient(options?.ctx);
     const id = this.resolveId(entity);
-    const stored = this.toStore({ ...entity, id } as DeepPartial<Entity>);
+    const stored = this.toStore({ ...entity, id } as DeepPartial<Entity>, {
+      materializeSoftDeleteNull: true,
+    });
     await client.create(this.options.collection, id, stored);
     this.markDirty(options?.ctx);
     return this.fromStore(stored);
@@ -325,8 +340,15 @@ export class FirestoreRepository<
    * (`startsWith('date') || endsWith('At')`). That made the returned
    * TYPE depend on the field NAME: `dateCreated` came back a `Date`,
    * `birthday` and `validFrom` came back strings.
+   *
+   * Soft-delete null is materialized **only on create**. Doing it on
+   * update/upsert/replace with `merge: true` would resurrect soft-deleted
+   * rows whenever the caller omitted the field (e.g. `update({ id }, patch)`).
    */
-  private toStore(entity: DeepPartial<Entity>): Record<string, unknown> {
+  private toStore(
+    entity: DeepPartial<Entity>,
+    options?: { readonly materializeSoftDeleteNull?: boolean },
+  ): Record<string, unknown> {
     const next: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(entity)) {
       if (value === undefined) {
@@ -337,6 +359,13 @@ export class FirestoreRepository<
     const id = (entity as { readonly id?: string }).id;
     if (typeof id === 'string') {
       next.id = id;
+    }
+    if (
+      options?.materializeSoftDeleteNull === true &&
+      this.softDeleteField !== undefined &&
+      !(this.softDeleteField in next)
+    ) {
+      next[this.softDeleteField] = null;
     }
     return next;
   }

--- a/packages/rockets-repository-firestore/src/repository/firestore-repository.ts
+++ b/packages/rockets-repository-firestore/src/repository/firestore-repository.ts
@@ -23,6 +23,7 @@ import {
 } from '../constants/firestore-soft-delete.constants';
 import { FIRESTORE_DEFAULT_TRANSACTION_KEY } from '../constants/firestore-transaction.constants';
 import { FIRESTORE_MAX_BATCH_WRITES } from '../constants/firestore-transaction.constants';
+import { FirestoreDuplicateIdException } from '../exceptions/firestore-duplicate-id.exception';
 import type { FirestoreBackend } from '../interfaces/firestore-backend.interface';
 import type {
   FirestoreOrderBy,
@@ -48,6 +49,12 @@ export interface FirestoreRepositoryOptions<Entity extends PlainLiteralObject> {
   readonly transactionKey?: string;
   /** Derive document id from this field when `id` is omitted on create. */
   readonly uniqueDocumentIdField?: string;
+}
+
+/** Firestore-only update options (CAS precondition). */
+export interface FirestoreRepositoryUpdateOptions
+  extends RepositoryUpdateOptions {
+  readonly precondition?: FirestoreWritePrecondition;
 }
 
 type StoreClient = Pick<
@@ -83,8 +90,11 @@ export class FirestoreRepository<
   }
 
   /**
-   * Atomic field increment without a full document read-modify-write.
-   * Prefer this for counters / heartbeats outside a transaction.
+   * Atomic field increment via `FieldValue.increment`. Writes only the named
+   * field — never a full-entity merge — so concurrent updates to other fields
+   * are not clobbered. Defaults to `exists: true` so a missing document fails
+   * the write instead of being created. Pass `{ precondition: undefined }` to
+   * opt out. Returns void; re-read if you need the new counter value.
    */
   async increment(
     entity: Entity,
@@ -97,14 +107,37 @@ export class FirestoreRepository<
   ): Promise<void> {
     const client = await this.resolveClient(options?.ctx);
     const id = this.resolveId(entity);
+    const precondition =
+      options !== undefined && 'precondition' in options
+        ? options.precondition
+        : { exists: true };
     await client.set(
       this.options.collection,
       id,
       { [field]: firestoreIncrement(delta) },
       true,
-      options?.precondition,
+      precondition,
     );
     this.markDirty(options?.ctx);
+  }
+
+  /**
+   * CAS update with an explicit write precondition. Prefer this over casting
+   * through {@link update} so the precondition stays on the typed surface.
+   */
+  async updateWithPrecondition(
+    entity: Entity,
+    data: DeepPartial<Entity>,
+    options: {
+      readonly precondition: FirestoreWritePrecondition;
+      readonly ctx?: PlainLiteralObject;
+    },
+  ): Promise<Entity> {
+    return this.permeator.update.permeate(
+      data,
+      (scoped) => this.doUpdate(entity, scoped, options),
+      this.entityCtx(options.ctx),
+    );
   }
 
   protected async doFind(
@@ -176,14 +209,6 @@ export class FirestoreRepository<
       return [];
     }
 
-    if (await this.isInTransaction(options?.ctx)) {
-      const created: Entity[] = [];
-      for (const entity of entities) {
-        created.push(await this.doCreate(entity, options));
-      }
-      return created;
-    }
-
     const prepared = entities.map((entity) => {
       const id = this.resolveId(entity);
       const stored = this.toStore({ ...entity, id } as DeepPartial<Entity>, {
@@ -191,6 +216,36 @@ export class FirestoreRepository<
       });
       return { id, stored };
     });
+
+    if (await this.isInTransaction(options?.ctx)) {
+      // Firestore: all reads before all writes. Hoist existence checks, then
+      // create with skipExistenceRead so the 2nd+ item does not read-after-write.
+      const client = await this.resolveClient(options?.ctx);
+      const seen = new Set<string>();
+      for (const row of prepared) {
+        if (seen.has(row.id)) {
+          throw new FirestoreDuplicateIdException(
+            this.options.collection,
+            row.id,
+          );
+        }
+        seen.add(row.id);
+        const existing = await client.get(this.options.collection, row.id);
+        if (existing !== null) {
+          throw new FirestoreDuplicateIdException(
+            this.options.collection,
+            row.id,
+          );
+        }
+      }
+      for (const row of prepared) {
+        await client.create(this.options.collection, row.id, row.stored, {
+          skipExistenceRead: true,
+        });
+      }
+      this.markDirty(options?.ctx);
+      return prepared.map((row) => this.fromStore(row.stored));
+    }
 
     for (
       let offset = 0;
@@ -214,12 +269,18 @@ export class FirestoreRepository<
   protected async doUpdate(
     entity: Entity,
     data: DeepPartial<Entity>,
-    options?: RepositoryUpdateOptions,
+    options?: FirestoreRepositoryUpdateOptions,
   ): Promise<Entity> {
     const client = await this.resolveClient(options?.ctx);
     const id = this.resolveId(entity);
     const merged = this.toStore({ ...entity, ...data, id });
-    await client.set(this.options.collection, id, merged, true);
+    await client.set(
+      this.options.collection,
+      id,
+      merged,
+      true,
+      options?.precondition,
+    );
     this.markDirty(options?.ctx);
     return this.fromStore(merged);
   }
@@ -250,13 +311,15 @@ export class FirestoreRepository<
   ): Promise<Entity> {
     const client = await this.resolveClient(options?.ctx);
     const id = this.resolveId(entity);
-    // Replace overwrites the whole document (`merge: false`). Carrying the
-    // soft-delete state from the loaded entity keeps a live row visible and
-    // a soft-deleted row deleted; the fallback covers entities built by hand.
-    const stored = this.toStore(
-      this.carrySoftDeleteField({ ...data, id }, entity),
-      { materializeSoftDeleteNull: true },
-    );
+    // Replace overwrites the whole document (`merge: false`). Carry the
+    // soft-delete state from the loaded entity when present; otherwise read
+    // the live document so a hand-built `{ id }` entity cannot invent `null`
+    // over a soft-deleted row.
+    const payload = this.carrySoftDeleteField({ ...data, id }, entity);
+    const materializeSoftDeleteNull =
+      await this.shouldMaterializeSoftDeleteOnReplace(client, id, payload);
+
+    const stored = this.toStore(payload, { materializeSoftDeleteNull });
     await client.set(this.options.collection, id, stored, false);
     this.markDirty(options?.ctx);
     return this.fromStore(stored);
@@ -441,6 +504,38 @@ export class FirestoreRepository<
     return existing === null;
   }
 
+  /**
+   * Decide whether replace may invent `softDeleteField: null`. Never invents
+   * over an existing soft-deleted (or live) document when the caller omitted
+   * the field — including hand-built `{ id }` entities.
+   */
+  private async shouldMaterializeSoftDeleteOnReplace(
+    client: StoreClient,
+    id: string,
+    payload: DeepPartial<Entity>,
+  ): Promise<boolean> {
+    const field = this.softDeleteField;
+    if (field === undefined) {
+      return false;
+    }
+    const record: Record<string, unknown> = { ...payload };
+    if (record[field] !== undefined) {
+      return false;
+    }
+    const existing = await client.get(this.options.collection, id);
+    if (existing === null) {
+      return true;
+    }
+    if (existing[field] !== undefined) {
+      // Mutate payload via carry path: stash store value onto the object
+      // the caller already built so toStore persists it.
+      (payload as Record<string, unknown>)[field] = existing[field];
+      return false;
+    }
+    // Legacy doc missing the field — materialize so it stays listable.
+    return true;
+  }
+
   private carrySoftDeleteField(
     target: DeepPartial<Entity>,
     source: Entity,
@@ -450,11 +545,12 @@ export class FirestoreRepository<
       return target;
     }
     const next: Record<string, unknown> = { ...target };
-    if (field in next) {
+    // Explicit `undefined` (common from DTO mapping) is "not provided".
+    if (next[field] !== undefined) {
       return target;
     }
     const current: Record<string, unknown> = { ...source };
-    if (!(field in current)) {
+    if (current[field] === undefined) {
       return target;
     }
     next[field] = current[field];

--- a/packages/rockets-repository-firestore/src/transaction/firestore-transaction-context.ts
+++ b/packages/rockets-repository-firestore/src/transaction/firestore-transaction-context.ts
@@ -1,0 +1,24 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+import type { FirestoreTransactionHandle } from '../interfaces/firestore-transaction-handle.interface';
+
+/**
+ * Ambient transactional handle for {@link runInFirestoreTransaction}.
+ * Kept module-private so only the callback-scoped API can populate it;
+ * repository `do*` methods read it via {@link getAmbientFirestoreTransaction}.
+ */
+const ambientFirestoreTransaction =
+  new AsyncLocalStorage<FirestoreTransactionHandle>();
+
+export function getAmbientFirestoreTransaction():
+  | FirestoreTransactionHandle
+  | undefined {
+  return ambientFirestoreTransaction.getStore();
+}
+
+export function runWithAmbientFirestoreTransaction<T>(
+  tx: FirestoreTransactionHandle,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return ambientFirestoreTransaction.run(tx, fn);
+}

--- a/packages/rockets-repository-firestore/src/transaction/firestore-transaction-context.ts
+++ b/packages/rockets-repository-firestore/src/transaction/firestore-transaction-context.ts
@@ -1,24 +1,47 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
+import type { FirestoreBackend } from '../interfaces/firestore-backend.interface';
 import type { FirestoreTransactionHandle } from '../interfaces/firestore-transaction-handle.interface';
+
+interface AmbientFirestoreTransaction {
+  readonly backend: FirestoreBackend;
+  readonly handle: FirestoreTransactionHandle;
+}
 
 /**
  * Ambient transactional handle for {@link runInFirestoreTransaction}.
  * Kept module-private so only the callback-scoped API can populate it;
  * repository `do*` methods read it via {@link getAmbientFirestoreTransaction}.
+ *
+ * The owning backend is stored with the handle: a Firestore transaction
+ * belongs to one database, so a repository bound to another backend must not
+ * join it.
  */
 const ambientFirestoreTransaction =
-  new AsyncLocalStorage<FirestoreTransactionHandle>();
+  new AsyncLocalStorage<AmbientFirestoreTransaction>();
 
-export function getAmbientFirestoreTransaction():
-  | FirestoreTransactionHandle
+/** The ambient handle, only when it belongs to `backend`. */
+export function getAmbientFirestoreTransaction(
+  backend: FirestoreBackend,
+): FirestoreTransactionHandle | undefined {
+  const ambient = ambientFirestoreTransaction.getStore();
+  if (ambient === undefined || ambient.backend !== backend) {
+    return undefined;
+  }
+  return ambient.handle;
+}
+
+/** The ambient entry regardless of owner — for nesting checks. */
+export function getAmbientFirestoreTransactionOwner():
+  | FirestoreBackend
   | undefined {
-  return ambientFirestoreTransaction.getStore();
+  return ambientFirestoreTransaction.getStore()?.backend;
 }
 
 export function runWithAmbientFirestoreTransaction<T>(
-  tx: FirestoreTransactionHandle,
+  backend: FirestoreBackend,
+  handle: FirestoreTransactionHandle,
   fn: () => Promise<T>,
 ): Promise<T> {
-  return ambientFirestoreTransaction.run(tx, fn);
+  return ambientFirestoreTransaction.run({ backend, handle }, fn);
 }

--- a/packages/rockets-repository-firestore/src/transaction/firestore-transaction-write-counter.ts
+++ b/packages/rockets-repository-firestore/src/transaction/firestore-transaction-write-counter.ts
@@ -1,0 +1,23 @@
+import { FIRESTORE_MAX_TRANSACTION_WRITES } from '../constants/firestore-transaction.constants';
+import { FirestoreTransactionWriteLimitExceededException } from '../exceptions/firestore-transaction-write-limit-exceeded.exception';
+
+/**
+ * Counts writes inside one transaction attempt and refuses the
+ * {@link FIRESTORE_MAX_TRANSACTION_WRITES} + 1st write early.
+ */
+export class FirestoreTransactionWriteCounter {
+  private writeCount = 0;
+
+  recordWrite(): void {
+    this.writeCount += 1;
+    if (this.writeCount > FIRESTORE_MAX_TRANSACTION_WRITES) {
+      throw new FirestoreTransactionWriteLimitExceededException(
+        this.writeCount,
+      );
+    }
+  }
+
+  get count(): number {
+    return this.writeCount;
+  }
+}

--- a/packages/rockets-repository-firestore/src/transaction/firestore-transaction.factory.ts
+++ b/packages/rockets-repository-firestore/src/transaction/firestore-transaction.factory.ts
@@ -1,0 +1,14 @@
+import type { TransactionFactoryInterface } from '@concepta/nestjs-repository';
+
+import type { FirestoreBackend } from '../interfaces/firestore-backend.interface';
+import { FirestoreTransaction } from './firestore-transaction';
+
+export class FirestoreTransactionFactory
+  implements TransactionFactoryInterface
+{
+  constructor(private readonly backend: FirestoreBackend) {}
+
+  create(): FirestoreTransaction {
+    return new FirestoreTransaction(this.backend);
+  }
+}

--- a/packages/rockets-repository-firestore/src/transaction/firestore-transaction.ts
+++ b/packages/rockets-repository-firestore/src/transaction/firestore-transaction.ts
@@ -1,0 +1,140 @@
+import type { TransactionInterface } from '@concepta/nestjs-repository';
+
+import { FirestoreTransactionAbortedException } from '../exceptions/firestore-transaction-aborted.exception';
+import { FirestoreTransactionRetryUnsupportedException } from '../exceptions/firestore-transaction-retry-unsupported.exception';
+import type { FirestoreBackend } from '../interfaces/firestore-backend.interface';
+import type { FirestoreTransactionHandle } from '../interfaces/firestore-transaction-handle.interface';
+
+/**
+ * Imperative bridge from Rockets' `TransactionInterface` onto Firestore's
+ * callback-shaped `runTransaction`.
+ *
+ * Firestore may retry the native attempt under contention. This bridge
+ * **refuses** a second attempt (throws
+ * {@link FirestoreTransactionRetryUnsupportedException}) instead of
+ * committing an empty write set and reporting success. Contended
+ * read-modify-write must use {@link FirestoreBackend.runTransaction} so the
+ * handler body lives inside the retryable callback.
+ */
+export class FirestoreTransaction implements TransactionInterface {
+  private handle: FirestoreTransactionHandle | null = null;
+  private _isDirty = false;
+  private attemptCount = 0;
+  private runPromise: Promise<void> | null = null;
+  private resolveCompletion: (() => void) | null = null;
+  private rejectCompletion: ((error: unknown) => void) | null = null;
+
+  constructor(private readonly backend: FirestoreBackend) {}
+
+  get isActive(): boolean {
+    return this.handle !== null;
+  }
+
+  get isDirty(): boolean {
+    return this._isDirty;
+  }
+
+  async start(): Promise<void> {
+    if (this.handle !== null || this.runPromise !== null) {
+      throw new FirestoreTransactionRetryUnsupportedException(
+        'Firestore transaction already started',
+      );
+    }
+
+    let resolveReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      resolveReady = resolve;
+    });
+
+    const completion = new Promise<void>((resolve, reject) => {
+      this.resolveCompletion = resolve;
+      this.rejectCompletion = reject;
+    });
+
+    // Prevent unhandled rejection if start() fails before commit/rollback.
+    let runFailure: unknown;
+    this.runPromise = this.backend
+      .runTransaction(async (tx) => {
+        this.attemptCount += 1;
+        if (this.attemptCount > 1) {
+          throw new FirestoreTransactionRetryUnsupportedException();
+        }
+        this.handle = tx;
+        resolveReady();
+        await completion;
+      })
+      .then(() => undefined)
+      .catch((error: unknown) => {
+        runFailure = error;
+        throw error;
+      });
+
+    // If runTransaction rejects before invoking the callback (credentials,
+    // project id, sync validation), ready never resolves — race it.
+    await Promise.race([
+      ready,
+      this.runPromise.then(() => {
+        throw (
+          runFailure ??
+          new FirestoreTransactionRetryUnsupportedException(
+            'Firestore transaction ended before start completed',
+          )
+        );
+      }),
+    ]);
+  }
+
+  markDirty(): void {
+    this._isDirty = true;
+  }
+
+  async commit(): Promise<void> {
+    if (!this.resolveCompletion || !this.runPromise) {
+      throw new FirestoreTransactionRetryUnsupportedException(
+        'No active Firestore transaction to commit',
+      );
+    }
+    try {
+      this.resolveCompletion();
+      await this.runPromise;
+    } finally {
+      this.cleanup();
+    }
+  }
+
+  async rollback(): Promise<void> {
+    if (!this.rejectCompletion || !this.runPromise) {
+      return;
+    }
+    try {
+      this.rejectCompletion(new FirestoreTransactionAbortedException());
+      try {
+        await this.runPromise;
+      } catch (error: unknown) {
+        if (!(error instanceof FirestoreTransactionAbortedException)) {
+          throw error;
+        }
+      }
+    } finally {
+      this.cleanup();
+    }
+  }
+
+  getClient<T = unknown>(): T {
+    if (!this.handle) {
+      throw new FirestoreTransactionRetryUnsupportedException(
+        'No active Firestore transaction — cannot get client',
+      );
+    }
+    return this.handle as T;
+  }
+
+  private cleanup(): void {
+    this.handle = null;
+    this._isDirty = false;
+    this.attemptCount = 0;
+    this.runPromise = null;
+    this.resolveCompletion = null;
+    this.rejectCompletion = null;
+  }
+}

--- a/packages/rockets-repository-firestore/src/transaction/firestore-transaction.ts
+++ b/packages/rockets-repository-firestore/src/transaction/firestore-transaction.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import type { TransactionInterface } from '@concepta/nestjs-repository';
 
 import { FirestoreTransactionAbortedException } from '../exceptions/firestore-transaction-aborted.exception';
@@ -13,10 +14,14 @@ import type { FirestoreTransactionHandle } from '../interfaces/firestore-transac
  * **refuses** a second attempt (throws
  * {@link FirestoreTransactionRetryUnsupportedException}) instead of
  * committing an empty write set and reporting success. Contended
- * read-modify-write must use {@link FirestoreBackend.runTransaction} so the
- * handler body lives inside the retryable callback.
+ * read-modify-write must use {@link FirestoreRepository.transaction} /
+ * {@link runInFirestoreTransaction} so the handler body lives inside the
+ * retryable callback.
  */
 export class FirestoreTransaction implements TransactionInterface {
+  private static readonly logger = new Logger(FirestoreTransaction.name);
+  private static warnedAboutRetryLimit = false;
+
   private handle: FirestoreTransactionHandle | null = null;
   private _isDirty = false;
   private attemptCount = 0;
@@ -35,6 +40,17 @@ export class FirestoreTransaction implements TransactionInterface {
   }
 
   async start(): Promise<void> {
+    if (!FirestoreTransaction.warnedAboutRetryLimit) {
+      FirestoreTransaction.warnedAboutRetryLimit = true;
+      FirestoreTransaction.logger.warn(
+        "TransactionScope / transactional:true uses Firestore's imperative " +
+          'bridge, which refuses SDK retries under contention ' +
+          '(FIRESTORE_TRANSACTION_RETRY_UNSUPPORTED). Prefer ' +
+          'FirestoreRepository.transaction() or runInFirestoreTransaction() ' +
+          'for contended read-modify-write.',
+      );
+    }
+
     if (this.handle !== null || this.runPromise !== null) {
       throw new FirestoreTransactionRetryUnsupportedException(
         'Firestore transaction already started',

--- a/packages/rockets-repository-firestore/src/transaction/run-in-firestore-transaction.ts
+++ b/packages/rockets-repository-firestore/src/transaction/run-in-firestore-transaction.ts
@@ -1,0 +1,26 @@
+import type { FirestoreBackend } from '../interfaces/firestore-backend.interface';
+import { runWithAmbientFirestoreTransaction } from './firestore-transaction-context';
+
+/**
+ * Run `fn` inside a real Firestore transaction attempt.
+ *
+ * Unlike the imperative `TransactionInterface` bridge (used by
+ * `TransactionScope`), the body lives **inside** the SDK callback, so a
+ * contended retry re-executes `fn`. Repository calls made during `fn`
+ * automatically join the ambient handle — no `{ ctx }` plumbing required.
+ *
+ * Prefer this for contended read-modify-write (rate limits, leases, turn
+ * locks, idempotent enqueue). Use `TransactionScope` only for uncontended
+ * multi-write units where a retry refusal is acceptable.
+ *
+ * Firestore limits a single transaction to 500 writes; exceeding that
+ * rejects the attempt (the adapter does not split batches).
+ */
+export async function runInFirestoreTransaction<T>(
+  backend: FirestoreBackend,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return backend.runTransaction((tx) =>
+    runWithAmbientFirestoreTransaction(tx, fn),
+  );
+}

--- a/packages/rockets-repository-firestore/src/transaction/run-in-firestore-transaction.ts
+++ b/packages/rockets-repository-firestore/src/transaction/run-in-firestore-transaction.ts
@@ -1,6 +1,7 @@
+import { FirestoreTransactionBackendMismatchException } from '../exceptions/firestore-transaction-backend-mismatch.exception';
 import type { FirestoreBackend } from '../interfaces/firestore-backend.interface';
 import {
-  getAmbientFirestoreTransaction,
+  getAmbientFirestoreTransactionOwner,
   runWithAmbientFirestoreTransaction,
 } from './firestore-transaction-context';
 
@@ -12,7 +13,11 @@ import {
  * contended retry re-executes `fn`. Repository calls made during `fn`
  * automatically join the ambient handle — no `{ ctx }` plumbing required.
  *
- * Nested calls join the ambient transaction (no second SDK transaction).
+ * Nesting on the same backend joins the ambient transaction instead of
+ * opening a second one (which would deadlock on the same document or commit
+ * two independent units). Nesting across backends throws, because a Firestore
+ * transaction cannot span databases.
+ *
  * Prefer this for contended read-modify-write (rate limits, leases, turn
  * locks, idempotent enqueue). Use `TransactionScope` only for uncontended
  * multi-write units where a retry refusal is acceptable.
@@ -24,10 +29,14 @@ export async function runInFirestoreTransaction<T>(
   backend: FirestoreBackend,
   fn: () => Promise<T>,
 ): Promise<T> {
-  if (getAmbientFirestoreTransaction() !== undefined) {
+  const ambientOwner = getAmbientFirestoreTransactionOwner();
+  if (ambientOwner !== undefined) {
+    if (ambientOwner !== backend) {
+      throw new FirestoreTransactionBackendMismatchException();
+    }
     return fn();
   }
   return backend.runTransaction((tx) =>
-    runWithAmbientFirestoreTransaction(tx, fn),
+    runWithAmbientFirestoreTransaction(backend, tx, fn),
   );
 }

--- a/packages/rockets-repository-firestore/src/transaction/run-in-firestore-transaction.ts
+++ b/packages/rockets-repository-firestore/src/transaction/run-in-firestore-transaction.ts
@@ -1,5 +1,8 @@
 import type { FirestoreBackend } from '../interfaces/firestore-backend.interface';
-import { runWithAmbientFirestoreTransaction } from './firestore-transaction-context';
+import {
+  getAmbientFirestoreTransaction,
+  runWithAmbientFirestoreTransaction,
+} from './firestore-transaction-context';
 
 /**
  * Run `fn` inside a real Firestore transaction attempt.
@@ -9,6 +12,7 @@ import { runWithAmbientFirestoreTransaction } from './firestore-transaction-cont
  * contended retry re-executes `fn`. Repository calls made during `fn`
  * automatically join the ambient handle — no `{ ctx }` plumbing required.
  *
+ * Nested calls join the ambient transaction (no second SDK transaction).
  * Prefer this for contended read-modify-write (rate limits, leases, turn
  * locks, idempotent enqueue). Use `TransactionScope` only for uncontended
  * multi-write units where a retry refusal is acceptable.
@@ -20,6 +24,9 @@ export async function runInFirestoreTransaction<T>(
   backend: FirestoreBackend,
   fn: () => Promise<T>,
 ): Promise<T> {
+  if (getAmbientFirestoreTransaction() !== undefined) {
+    return fn();
+  }
   return backend.runTransaction((tx) =>
     runWithAmbientFirestoreTransaction(tx, fn),
   );

--- a/packages/rockets-repository-firestore/src/utils/admin-stream-backfill-soft-delete-null.ts
+++ b/packages/rockets-repository-firestore/src/utils/admin-stream-backfill-soft-delete-null.ts
@@ -1,0 +1,57 @@
+import { getApp } from 'firebase-admin/app';
+import {
+  getFirestore,
+  type DocumentSnapshot,
+  type Firestore,
+} from 'firebase-admin/firestore';
+
+export interface AdminStreamBackfillSoftDeleteNullOptions {
+  readonly collection: string;
+  readonly softDeleteField: string;
+  readonly db?: Firestore;
+}
+
+function isDocumentSnapshot(value: unknown): value is DocumentSnapshot {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'ref' in value &&
+    'data' in value &&
+    typeof (value as DocumentSnapshot).data === 'function'
+  );
+}
+
+/**
+ * Production-scale soft-delete backfill: streams the collection and patches
+ * missing markers with Admin {@link BulkWriter} (non-atomic, high throughput).
+ *
+ * Prefer this over {@link backfillSoftDeleteNull} for large collections —
+ * that helper loads every document into memory first.
+ *
+ * @returns number of documents patched
+ */
+export async function adminStreamBackfillSoftDeleteNull(
+  options: AdminStreamBackfillSoftDeleteNullOptions,
+): Promise<number> {
+  const db = options.db ?? getFirestore(getApp());
+  const writer = db.bulkWriter();
+  let patched = 0;
+
+  for await (const raw of db.collection(options.collection).stream()) {
+    if (!isDocumentSnapshot(raw)) {
+      continue;
+    }
+    const data = raw.data();
+    if (
+      data !== undefined &&
+      Object.prototype.hasOwnProperty.call(data, options.softDeleteField)
+    ) {
+      continue;
+    }
+    writer.set(raw.ref, { [options.softDeleteField]: null }, { merge: true });
+    patched += 1;
+  }
+
+  await writer.close();
+  return patched;
+}

--- a/packages/rockets-repository-firestore/src/utils/backfill-soft-delete-null.ts
+++ b/packages/rockets-repository-firestore/src/utils/backfill-soft-delete-null.ts
@@ -1,0 +1,46 @@
+import type { FirestoreBackend } from '../interfaces/firestore-backend.interface';
+
+export interface BackfillSoftDeleteNullOptions {
+  readonly backend: Pick<FirestoreBackend, 'queryBranch' | 'set'>;
+  readonly collection: string;
+  readonly softDeleteField: string;
+}
+
+/**
+ * Patch documents that omit {@link BackfillSoftDeleteNullOptions.softDeleteField}
+ * with an explicit `null` so server-side soft-delete exclusion (`field == null`)
+ * can see them.
+ *
+ * Loads the whole collection via `queryBranch` — fine for emulator / small
+ * collections. For large production collections, prefer an Admin SDK
+ * `collection.stream()` + `BulkWriter` loop (see README).
+ *
+ * @returns number of documents patched
+ */
+export async function backfillSoftDeleteNull(
+  options: BackfillSoftDeleteNullOptions,
+): Promise<number> {
+  const { backend, collection, softDeleteField } = options;
+  const rows = await backend.queryBranch(collection, {
+    branch: { filters: [], postFilters: [] },
+  });
+
+  let patched = 0;
+  for (const row of rows) {
+    const id = row.id;
+    if (typeof id !== 'string' || id.length === 0) {
+      continue;
+    }
+    if (softDeleteField in row) {
+      continue;
+    }
+    await backend.set(
+      collection,
+      id,
+      { ...row, [softDeleteField]: null },
+      true,
+    );
+    patched += 1;
+  }
+  return patched;
+}

--- a/packages/rockets-repository-firestore/src/utils/firestore-deterministic-id.ts
+++ b/packages/rockets-repository-firestore/src/utils/firestore-deterministic-id.ts
@@ -1,5 +1,7 @@
 import { createHash } from 'node:crypto';
 
+import { FirestoreInvalidDocumentIdException } from '../exceptions/firestore-invalid-document-id.exception';
+
 /**
  * Derive a Firestore document id from a single unique field value.
  *
@@ -10,7 +12,7 @@ export function deriveFirestoreDocumentId(
   options?: { readonly hashPrefix?: string },
 ): string {
   if (typeof value !== 'string' || value.trim().length === 0) {
-    throw new Error(
+    throw new FirestoreInvalidDocumentIdException(
       'Firestore uniqueDocumentIdField must be a non-empty string on create',
     );
   }
@@ -24,10 +26,16 @@ export function deriveFirestoreDocumentId(
 }
 
 function isSafeFirestoreDocumentId(value: string): boolean {
-  if (value.length > 1500) {
+  if (Buffer.byteLength(value, 'utf8') > 1500) {
     return false;
   }
-  if (value.includes('/') || value.includes('..')) {
+  if (value === '.' || value === '..') {
+    return false;
+  }
+  if (value.includes('/')) {
+    return false;
+  }
+  if (/^__.*__$/.test(value)) {
     return false;
   }
   return true;

--- a/packages/rockets-repository-firestore/src/utils/firestore-deterministic-id.ts
+++ b/packages/rockets-repository-firestore/src/utils/firestore-deterministic-id.ts
@@ -1,0 +1,34 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Derive a Firestore document id from a single unique field value.
+ *
+ * Prefer the raw string when it is a safe document id; otherwise hash.
+ */
+export function deriveFirestoreDocumentId(
+  value: unknown,
+  options?: { readonly hashPrefix?: string },
+): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(
+      'Firestore uniqueDocumentIdField must be a non-empty string on create',
+    );
+  }
+  const trimmed = value.trim();
+  if (isSafeFirestoreDocumentId(trimmed)) {
+    return trimmed;
+  }
+  const prefix = options?.hashPrefix ?? 'u';
+  const digest = createHash('sha256').update(trimmed).digest('hex');
+  return `${prefix}_${digest}`;
+}
+
+function isSafeFirestoreDocumentId(value: string): boolean {
+  if (value.length > 1500) {
+    return false;
+  }
+  if (value.includes('/') || value.includes('..')) {
+    return false;
+  }
+  return true;
+}

--- a/packages/rockets-repository-firestore/src/utils/firestore-precondition.util.ts
+++ b/packages/rockets-repository-firestore/src/utils/firestore-precondition.util.ts
@@ -1,0 +1,45 @@
+import { Timestamp, type Precondition } from 'firebase-admin/firestore';
+
+import { FirestoreInvalidPreconditionException } from '../exceptions/firestore-invalid-precondition.exception';
+import type { FirestoreWritePrecondition } from '../interfaces/firestore-write.interface';
+
+/**
+ * Normalize a write precondition for the Admin SDK.
+ *
+ * A set/update with a precondition uses update semantics (document must
+ * exist). Combining `exists` with `lastUpdateTime` is rejected by Firestore.
+ * `exists: false` is legal on delete only.
+ */
+export function toAdminPrecondition(
+  precondition: FirestoreWritePrecondition | undefined,
+  mode: 'set' | 'delete' = 'set',
+): Precondition | undefined {
+  if (precondition === undefined) {
+    return undefined;
+  }
+  if (
+    precondition.lastUpdateTime !== undefined &&
+    precondition.exists !== undefined
+  ) {
+    throw new FirestoreInvalidPreconditionException(
+      'Firestore precondition cannot set both lastUpdateTime and exists',
+    );
+  }
+  if (precondition.exists === false) {
+    if (mode === 'set') {
+      throw new FirestoreInvalidPreconditionException(
+        'Firestore set/update precondition cannot require exists: false — use create()',
+      );
+    }
+    return { exists: false };
+  }
+  if (precondition.lastUpdateTime !== undefined) {
+    return {
+      lastUpdateTime: Timestamp.fromDate(precondition.lastUpdateTime),
+    };
+  }
+  if (precondition.exists === true) {
+    return { exists: true };
+  }
+  return undefined;
+}

--- a/packages/rockets-repository-firestore/src/utils/firestore-repository.util.ts
+++ b/packages/rockets-repository-firestore/src/utils/firestore-repository.util.ts
@@ -62,7 +62,11 @@ export function createFirestoreProvider(
   backend: FirestoreBackend,
   transactionKey: string = resolveFirestoreTransactionKey(backend),
 ): Provider {
+  assertSupportedUniqueConstraints(options);
   const collection = options.collection ?? options.key;
+  const uniqueDocumentIdField =
+    options.uniqueDocumentIdField ??
+    resolveSingleUniqueField(options.uniqueConstraints);
 
   return {
     provide: getDynamicRepositoryToken(options.key),
@@ -78,9 +82,45 @@ export function createFirestoreProvider(
         metadata,
         backend,
         transactionKey,
+        uniqueDocumentIdField,
       });
     },
   };
+}
+
+function resolveSingleUniqueField(
+  constraints: ReadonlyArray<ReadonlyArray<string>> | undefined,
+): string | undefined {
+  if (!constraints || constraints.length !== 1) {
+    return undefined;
+  }
+  const first = constraints[0];
+  if (first === undefined || first.length !== 1) {
+    return undefined;
+  }
+  return first[0];
+}
+
+/**
+ * Composite uniqueness needs a secondary index collection (issue #44 P1-3
+ * tier 2). Refuse at boot so apps do not silently accept unenforceable
+ * constraints.
+ */
+function assertSupportedUniqueConstraints(
+  options: FirestoreProviderOptions,
+): void {
+  const constraints = options.uniqueConstraints ?? [];
+  for (const constraint of constraints) {
+    if (constraint.length > 1) {
+      throw new Error(
+        `Firestore adapter: composite unique constraint [${constraint.join(
+          ', ',
+        )}] on entity "${options.key}" is not supported yet — use a single ` +
+          `uniqueDocumentIdField / natural document id, or wait for the ` +
+          `uniqueness-index collection (issue #44 P1-3 tier 2).`,
+      );
+    }
+  }
 }
 
 export function createFirestoreTransactionFactoryDescriptor(

--- a/packages/rockets-repository-firestore/src/utils/firestore-repository.util.ts
+++ b/packages/rockets-repository-firestore/src/utils/firestore-repository.util.ts
@@ -7,6 +7,7 @@ import {
 } from '@concepta/nestjs-repository';
 
 import { AdminFirestoreBackend } from '../backends/admin-firestore.backend';
+import { FIRESTORE_BACKEND } from '../constants/firestore-repository.constants';
 import { FIRESTORE_DEFAULT_TRANSACTION_KEY } from '../constants/firestore-transaction.constants';
 import { FirestoreRepositoryModule } from '../firestore-repository.module';
 import type { FirestoreBackend } from '../interfaces/firestore-backend.interface';
@@ -102,10 +103,16 @@ export function createFirestoreFeatureModule(
 
   return {
     module: FirestoreRepositoryModule,
-    providers: entities.map((entity) =>
-      createFirestoreProvider(entity, resolvedBackend, transactionKey),
-    ),
-    exports: entities.map((entity) => getDynamicRepositoryToken(entity.key)),
+    providers: [
+      { provide: FIRESTORE_BACKEND, useValue: resolvedBackend },
+      ...entities.map((entity) =>
+        createFirestoreProvider(entity, resolvedBackend, transactionKey),
+      ),
+    ],
+    exports: [
+      FIRESTORE_BACKEND,
+      ...entities.map((entity) => getDynamicRepositoryToken(entity.key)),
+    ],
     transactionFactories: [
       createFirestoreTransactionFactoryDescriptor(
         resolvedBackend,

--- a/packages/rockets-repository-firestore/src/utils/firestore-repository.util.ts
+++ b/packages/rockets-repository-firestore/src/utils/firestore-repository.util.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import type { Provider } from '@nestjs/common';
 import { getApp, getApps } from 'firebase-admin/app';
 import {
@@ -6,11 +7,36 @@ import {
 } from '@concepta/nestjs-repository';
 
 import { AdminFirestoreBackend } from '../backends/admin-firestore.backend';
+import { FIRESTORE_DEFAULT_TRANSACTION_KEY } from '../constants/firestore-transaction.constants';
 import { FirestoreRepositoryModule } from '../firestore-repository.module';
 import type { FirestoreBackend } from '../interfaces/firestore-backend.interface';
 import type { FirestoreProviderOptions } from '../interfaces/firestore-provider-options.interface';
 import { buildFirestoreEntityMetadata } from '../repository/firestore-entity-metadata';
 import { FirestoreRepository } from '../repository/firestore-repository';
+import { FirestoreTransactionFactory } from '../transaction/firestore-transaction.factory';
+
+type FirestoreTransactionFactoryDescriptor = NonNullable<
+  DynamicRepositoryModule['transactionFactories']
+>[number];
+
+const backendTransactionKeys = new WeakMap<FirestoreBackend, string>();
+
+/**
+ * Stable per-backend transaction key. Identity is the backend instance
+ * (WeakMap), and the suffix is a UUID assigned once — no process-global
+ * counter, no boot-order-dependent numbering.
+ */
+export function resolveFirestoreTransactionKey(
+  backend: FirestoreBackend,
+): string {
+  const existing = backendTransactionKeys.get(backend);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const key = `${FIRESTORE_DEFAULT_TRANSACTION_KEY}:${randomUUID()}`;
+  backendTransactionKeys.set(backend, key);
+  return key;
+}
 
 export function resolveFirestoreBackend(
   backend?: FirestoreBackend,
@@ -33,6 +59,7 @@ export function resolveFirestoreBackend(
 export function createFirestoreProvider(
   options: FirestoreProviderOptions,
   backend: FirestoreBackend,
+  transactionKey: string = resolveFirestoreTransactionKey(backend),
 ): Provider {
   const collection = options.collection ?? options.key;
 
@@ -49,8 +76,20 @@ export function createFirestoreProvider(
         collection,
         metadata,
         backend,
+        transactionKey,
       });
     },
+  };
+}
+
+export function createFirestoreTransactionFactoryDescriptor(
+  backend: FirestoreBackend,
+  transactionKey: string = resolveFirestoreTransactionKey(backend),
+): FirestoreTransactionFactoryDescriptor {
+  return {
+    key: transactionKey,
+    inject: [],
+    useFactory: () => new FirestoreTransactionFactory(backend),
   };
 }
 
@@ -59,12 +98,19 @@ export function createFirestoreFeatureModule(
   backend?: FirestoreBackend,
 ): DynamicRepositoryModule {
   const resolvedBackend = resolveFirestoreBackend(backend);
+  const transactionKey = resolveFirestoreTransactionKey(resolvedBackend);
 
   return {
     module: FirestoreRepositoryModule,
     providers: entities.map((entity) =>
-      createFirestoreProvider(entity, resolvedBackend),
+      createFirestoreProvider(entity, resolvedBackend, transactionKey),
     ),
     exports: entities.map((entity) => getDynamicRepositoryToken(entity.key)),
+    transactionFactories: [
+      createFirestoreTransactionFactoryDescriptor(
+        resolvedBackend,
+        transactionKey,
+      ),
+    ],
   };
 }

--- a/scripts/run-emulator-suite.mjs
+++ b/scripts/run-emulator-suite.mjs
@@ -9,6 +9,25 @@ if (process.env.SKIP_EMULATOR && !process.env.CI) {
   process.exit(0);
 }
 
+function assertJdk21OrNewer() {
+  const result = spawnSync('java', ['-version'], { encoding: 'utf8' });
+  const output = `${result.stderr ?? ''}${result.stdout ?? ''}`;
+  const match = /version "(\d+)/.exec(output);
+  const major = match ? Number(match[1]) : Number.NaN;
+  if (!Number.isFinite(major) || major < 21) {
+    console.error(
+      'Firestore emulator requires JDK 21+ (firebase-tools). ' +
+        `Detected: ${match ? `Java ${major}` : 'no usable java -version'}.\n` +
+        'Install a modern JDK (e.g. `brew install openjdk@21`) and ensure ' +
+        '`java -version` reports 21+, or set SKIP_EMULATOR=1 locally ' +
+        '(CI never skips).',
+    );
+    process.exit(1);
+  }
+}
+
+assertJdk21OrNewer();
+
 // firebase-tools is intentionally not a workspace dependency — the pinned
 // npx invocation is the single place that names its version.
 const result = spawnSync(
@@ -27,4 +46,5 @@ const result = spawnSync(
   ],
   { stdio: 'inherit' },
 );
+
 process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary
- **P1-1 transactions:** `runInFirestoreTransaction` / `FirestoreRepository.transaction()` keep the body inside the SDK callback (retries re-execute); `FIRESTORE_BACKEND` DI export; imperative `TransactionScope` bridge fails closed on retry and warns once; nested callback txs join ambient ALS.
- **P1-4 soft-delete pushdown:** default lists/counts use server-side `field == null` so `limit()` / aggregation work again; create materializes explicit `null` only (update/upsert do not — avoids silent resurrection).
- **Production migration helpers:** `backfillSoftDeleteNull`, `firestore.indexes.example.json`, and README notes that the emulator does not catch missing composite indexes (`FAILED_PRECONDITION` in prod).

Stacked on #42 (`fix/hardening-pre-alpha`). Closes the transactional half of issue #44 (b) plus soft-delete billing/scan impact; not claiming full production-ready yet (P1-2 increment/CAS, P1-5 orderBy, P1-6 WriteBatch still open).

## Test plan
- [x] `yarn build` + unit tests in `packages/rockets-repository-firestore` (69 passing)
- [ ] `corepack yarn test:firestore-emulator` (needs JDK 21) — contended counter / multi-doc / lease takeover cases included
- [ ] Confirm soft-deleted row stays deleted after `update({ id }, patch)` / upsert omitting `dateRemoved`
- [ ] Confirm nested `runInFirestoreTransaction` opens only one SDK transaction
- [ ] On a real project: deploy indexes from `firestore.indexes.example.json` and run `backfillSoftDeleteNull` (or Admin BulkWriter) before flipping to this adapter version


Made with [Cursor](https://cursor.com)